### PR TITLE
Improve the design of esockd_connection_sup module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: erlang
 
 otp_release:
-   - 20.0
-   - 19.3
-   - 18.3
-   - 17.0
+   - 21.0.4
 
-script: 
+script:
   - make
 
 sudo: false

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = esockd
 PROJECT_DESCRIPTION = General Non-blocking TCP/SSL Server
-PROJECT_VERSION = 5.4
+PROJECT_VERSION = 5.4.1
 PROJECT_REGISTERED = esockd_server
 
 LOCAL_DEPS = ssl

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# esockd [![Build Status](https://travis-ci.org/emqtt/esockd.svg?branch=3.0)](https://travis-ci.org/emqtt/esockd)
+# esockd [![Build Status](https://travis-ci.org/emqx/esockd.svg?branch=emqx30)](https://travis-ci.org/emqx/esockd)
 
 Erlang General Non-blocking TCP/SSL Socket Server.
 
@@ -200,5 +200,5 @@ Apache License Version 2.0
 
 ## Author
 
-Feng Lee <feng@emqx.io>
+EMQ X Team.
 

--- a/include/esockd.hrl
+++ b/include/esockd.hrl
@@ -12,6 +12,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 
+-ifndef(ESOCKD_HRL).
+-define(ESOCKD_HRL, true).
+
 %%--------------------------------------------------------------------
 %% Default Timeout
 %%--------------------------------------------------------------------
@@ -59,3 +62,4 @@
 
 -define(IS_PROXY(Sock), is_record(Sock, proxy_socket)).
 
+-endif.

--- a/src/esockd.app.src
+++ b/src/esockd.app.src
@@ -1,6 +1,6 @@
 {application, esockd, [
   {id, "esockd"},
-  {vsn, "5.4"},
+  {vsn, "5.4.1"},
   {description, "General Non-blocking TCP/SSL Server"},
   {modules, []},
   {registered, []},

--- a/src/esockd_acceptor.erl
+++ b/src/esockd_acceptor.erl
@@ -24,15 +24,17 @@
 %% gen_statem Callbacks
 -export([init/1, callback_mode/0, terminate/3, code_change/4]).
 
--record(state, {lsock        :: inet:socket(),
-                sockmod      :: module(),
-                sockname     :: {inet:ip_address(), inet:port_number()},
-                tune_fun     :: esockd:sock_fun(),
-                upgrade_funs :: [esockd:sock_fun()],
-                stats_fun    :: fun(),
-                limit_fun    :: fun(),
-                conn_sup     :: pid(),
-                accept_ref   :: term()}).
+-record(state, {
+          lsock        :: inet:socket(),
+          sockmod      :: module(),
+          sockname     :: {inet:ip_address(), inet:port_number()},
+          tune_fun     :: esockd:sock_fun(),
+          upgrade_funs :: [esockd:sock_fun()],
+          stats_fun    :: fun(),
+          limit_fun    :: fun(),
+          conn_sup     :: pid(),
+          accept_ref   :: term()
+         }).
 
 %% @doc Start an acceptor
 -spec(start_link(pid(), esockd:sock_fun(), [esockd:sock_fun()], fun(), fun(), inet:socket())

--- a/src/esockd_listener.erl
+++ b/src/esockd_listener.erl
@@ -23,12 +23,14 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
          code_change/3]).
 
--record(state, {proto     :: atom(),
-                listen_on :: esockd:listen_on(),
-                options   :: [esockd:option()],
-                lsock     :: inet:socket(),
-                laddr     :: inet:ip_address(),
-                lport     :: inet:port_number()}).
+-record(state, {
+          proto     :: atom(),
+          listen_on :: esockd:listen_on(),
+          options   :: [esockd:option()],
+          lsock     :: inet:socket(),
+          laddr     :: inet:ip_address(),
+          lport     :: inet:port_number()
+         }).
 
 -define(ACCEPTOR_POOL, 16).
 -define(DEFAULT_TCP_OPTIONS, [{nodelay, true},

--- a/src/esockd_rate_limit.erl
+++ b/src/esockd_rate_limit.erl
@@ -22,10 +22,12 @@
 
 -export([new/2, info/1, check/2, check/3]).
 
--record(bucket, {burst   :: pos_integer(),
-                 tokens  :: non_neg_integer(),
-                 rate    :: float(),
-                 lastime :: pos_integer()}).
+-record(bucket, {
+          burst   :: pos_integer(),
+          tokens  :: non_neg_integer(),
+          rate    :: float(),
+          lastime :: pos_integer()
+         }).
 
 -type(bucket() :: #bucket{}).
 


### PR DESCRIPTION
1. Use map to store connection pids instead of process dictionary.
2. Change the format of record definition in some modules.
3. Bump version to 5.4.1