### PR TITLE
Enhance Ratelimit checking

### DIFF
--- a/src/esockd_limiter.erl
+++ b/src/esockd_limiter.erl
@@ -109,7 +109,7 @@ consume(Name, Tokens) when is_integer(Tokens), Tokens > 0 ->
         0 -> {0, pause_time(Name, erlang:system_time(millisecond))};
         I -> {I, 0}
     catch
-        error:badarg -> {-1, 1000} %% pause for 1 second
+        error:badarg -> {1, 0}
     end.
 
 %% @private

--- a/src/esockd_limiter.erl
+++ b/src/esockd_limiter.erl
@@ -52,10 +52,12 @@
 
 -export_type([bucket_info/0]).
 
-%%-record(bucket, {name, capacity, interval, lastime}).
-
 -define(TAB, ?MODULE).
 -define(SERVER, ?MODULE).
+
+%%--------------------------------------------------------------------
+%% APIs
+%%--------------------------------------------------------------------
 
 -spec(start_link() -> {ok, pid()}).
 start_link() ->
@@ -96,7 +98,8 @@ lookup(Name) ->
         [Bucket] -> bucket_info(Bucket)
     end.
 
--spec(consume(bucket_name()) -> {integer(), integer()}).
+-spec(consume(bucket_name())
+      -> {Remaing :: integer(), PasueMillSec :: integer()}).
 consume(Name) ->
     consume(Name, 1).
 

--- a/test/esockd_limiter_SUITE.erl
+++ b/test/esockd_limiter_SUITE.erl
@@ -86,7 +86,7 @@ t_consume(_) ->
     ok = timer:sleep(1020),
     #{tokens := 10} = esockd_limiter:lookup(bucket),
     {5, 0} = esockd_limiter:consume(bucket, 5),
-    {-1, 1000} = esockd_limiter:consume(notexisted, 1),
+    {1, 0} = esockd_limiter:consume(notexisted, 1),
     ok = esockd_limiter:stop().
 
 t_concurrent_consume(_) ->


### PR DESCRIPTION
1. Add concurrency consuming case for `esockd_limiter`
2. Make more precise pause time for `esockd_rate_limit`