### PR TITLE
Release 5.7.2

### DIFF
--- a/src/esockd_limiter.erl
+++ b/src/esockd_limiter.erl
@@ -109,7 +109,7 @@ consume(Name, Tokens) when is_integer(Tokens), Tokens > 0 ->
         0 -> {0, pause_time(Name, erlang:system_time(millisecond))};
         I -> {I, 0}
     catch
-        error:badarg -> {-1, 1000} %% pause for 1 second
+        error:badarg -> {1, 0}
     end.
 
 %% @private

--- a/src/esockd_limiter.erl
+++ b/src/esockd_limiter.erl
@@ -43,12 +43,12 @@
 
 -type(bucket_name() :: term()).
 
--opaque(bucket_info() :: #{name      => bucket_name(),
-                           capacity  => pos_integer(),
-                           interval  => pos_integer(),
-                           tokens    => pos_integer(),
-                           lasttime  => integer()
-                          }).
+-type(bucket_info() :: #{name      => bucket_name(),
+                         capacity  => pos_integer(),
+                         interval  => pos_integer(),
+                         tokens    => pos_integer(),
+                         lasttime  => integer()
+                        }).
 
 -export_type([bucket_info/0]).
 

--- a/src/esockd_limiter.erl
+++ b/src/esockd_limiter.erl
@@ -52,10 +52,12 @@
 
 -export_type([bucket_info/0]).
 
-%%-record(bucket, {name, capacity, interval, lastime}).
-
 -define(TAB, ?MODULE).
 -define(SERVER, ?MODULE).
+
+%%--------------------------------------------------------------------
+%% APIs
+%%--------------------------------------------------------------------
 
 -spec(start_link() -> {ok, pid()}).
 start_link() ->
@@ -96,7 +98,8 @@ lookup(Name) ->
         [Bucket] -> bucket_info(Bucket)
     end.
 
--spec(consume(bucket_name()) -> {integer(), integer()}).
+-spec(consume(bucket_name())
+      -> {Remaing :: integer(), PasueMillSec :: integer()}).
 consume(Name) ->
     consume(Name, 1).
 

--- a/src/esockd_limiter.erl
+++ b/src/esockd_limiter.erl
@@ -82,11 +82,11 @@ stop() ->
 
 -spec(create(bucket_name(), pos_integer()) -> ok).
 create(Name, Capacity) when is_integer(Capacity), Capacity > 0 ->
-    create(Name, Capacity , 1).
+    create(Name, Capacity, 1).
 
 -spec(create(bucket_name(), pos_integer(), pos_integer()) -> ok).
-create(Name, Capacity , Interval) when is_integer(Capacity), Capacity > 0,
-                                       is_integer(Interval), Interval > 0 ->
+create(Name, Capacity, Interval) when is_integer(Capacity), Capacity > 0,
+                                      is_integer(Interval), Interval > 0 ->
     gen_server:call(?SERVER, {create, Name, Capacity, Interval}).
 
 -spec(lookup(bucket_name()) -> undefined | bucket_info()).

--- a/src/esockd_sup.erl
+++ b/src/esockd_sup.erl
@@ -106,14 +106,17 @@ terminate_and_delete(ChildId) ->
 listeners() ->
     [{Id, Pid} || {{listener_sup, Id}, Pid, _Type, _} <- supervisor:which_children(?MODULE)].
 
--spec(listener({atom(), esockd:listen_on()}) -> undefined | pid()).
+-spec(listener({atom(), esockd:listen_on()}) -> pid()).
 listener({Proto, ListenOn}) ->
     ChildId = child_id(Proto, ListenOn),
     case [Pid || {Id, Pid, _Type, _} <- supervisor:which_children(?MODULE), Id =:= ChildId] of
-        [] -> undefined;
+        [] -> error(not_found);
         L  -> hd(L)
     end.
 
+-spec(listener_and_module({atom(), esockd:listen_on()})
+     -> undefined
+      | {ListenerSup :: pid(), Mod :: esockd_listener_sup | esockd_udp}).
 listener_and_module({Proto, ListenOn}) ->
     ChildId = child_id(Proto, ListenOn),
     case [{Pid, Mod} || {Id, Pid, _Type, [Mod|_]} <- supervisor:which_children(?MODULE), Id =:= ChildId] of

--- a/test/esockd_SUITE.erl
+++ b/test/esockd_SUITE.erl
@@ -127,7 +127,7 @@ t_listeners(_) ->
     ?assertEqual(LSup, esockd:listener({echo, 6000})),
     ok = esockd:close(echo, 6000),
     [] = esockd:listeners(),
-    ?assertEqual(undefined, esockd:listener({echo, 6000})).
+    ?assertException(error, not_found, esockd:listener({echo, 6000})).
 
 t_get_stats(_) ->
     {ok, _LSup} = esockd:open(echo, 6000, [], {echo_server, start_link, []}),
@@ -144,19 +144,19 @@ t_get_options(_) ->
                               {echo_server, start_link, []}),
     [{acceptors, 4}] = esockd:get_options({echo, 6000}),
     ok = esockd:close(echo, 6000),
-    undefined = esockd:get_options({echo, 6000}),
+    ?assertException(error, not_found, esockd:get_options({echo, 6000})),
 
     {ok, _LSup1} = esockd:open_dtls(dtls_echo, 6000, [{acceptors, 4}],
                                {dtls_echo_server, start_link, []}),
     [{acceptors, 4}] = esockd:get_options({dtls_echo, 6000}),
     ok = esockd:close(dtls_echo, 6000),
-    undefined = esockd:get_options({dtls_echo, 6000}),
+    ?assertException(error, not_found, esockd:get_options({dtls_echo, 6000})),
 
     {ok, _LSup2} = esockd:open_udp(udp_echo, 6000, [{acceptors, 4}],
                                {udp_echo_server, start_link, []}),
     [{acceptors, 4}] = esockd:get_options({udp_echo, 6000}),
     ok = esockd:close(udp_echo, 6000),
-    undefined = esockd:get_options({udp_echo, 6000}).
+    ?assertException(error, not_found, esockd:get_options({udp_echo, 6000})).
 
 t_get_acceptors(_) ->
     {ok, _LSup} = esockd:open(echo, 6000, [{acceptors, 4}],
@@ -196,6 +196,32 @@ t_get_set_max_connections(_) ->
     esockd:set_max_connections({udp_echo, 7000}, 16),
     ?assertEqual(16, esockd:get_max_connections({udp_echo, 7000})),
     ok = esockd:close(udp_echo, 7000).
+
+t_get_set_max_conn_rate(_) ->
+    {ok, _LSup} = esockd:open(echo, 7000, [{max_conn_rate, {100, 1}}],
+                              {echo_server, start_link, []}),
+    ?assertEqual({100, 1}, esockd:get_max_conn_rate({echo, 7000})),
+    esockd:set_max_conn_rate({echo, 7000}, {50, 2}),
+    ?assertEqual({50, 2}, esockd:get_max_conn_rate({echo, 7000})),
+    ok = esockd:close(echo, 7000),
+    ?assertException(error, not_found, esockd:get_max_conn_rate({echo, 7000})),
+
+
+    {ok, _LSup1} = esockd:open_dtls(dtls_echo, 7000, [{max_conn_rate, {100, 1}}],
+                               {dtls_echo_server, start_link, []}),
+    ?assertEqual({100, 1}, esockd:get_max_conn_rate({dtls_echo, 7000})),
+    esockd:set_max_conn_rate({dtls_echo, 7000}, {50, 2}),
+    ?assertEqual({50, 2}, esockd:get_max_conn_rate({dtls_echo, 7000})),
+    ok = esockd:close(dtls_echo, 7000),
+    ?assertException(error, not_found, esockd:get_max_conn_rate({dtls_echo, 7000})),
+
+    {ok, _LSup2} = esockd:open_udp(udp_echo, 7000, [{max_conn_rate, {100, 1}}],
+                               {udp_echo_server, start_link, []}),
+    ?assertEqual({100, 1}, esockd:get_max_conn_rate({udp_echo, 7000})),
+    esockd:set_max_conn_rate({udp_echo, 7000}, {50, 2}),
+    ?assertEqual({50, 2}, esockd:get_max_conn_rate({udp_echo, 7000})),
+    ok = esockd:close(udp_echo, 7000),
+    ?assertException(error, not_found, esockd:get_max_conn_rate({udp_echo, 7000})).
 
 t_get_current_connections(Config) ->
     {ok, _LSup} = esockd:open(echo, 7000, [], {echo_server, start_link, []}),

--- a/test/esockd_limiter_SUITE.erl
+++ b/test/esockd_limiter_SUITE.erl
@@ -86,7 +86,7 @@ t_consume(_) ->
     ok = timer:sleep(1020),
     #{tokens := 10} = esockd_limiter:lookup(bucket),
     {5, 0} = esockd_limiter:consume(bucket, 5),
-    {-1, 1000} = esockd_limiter:consume(notexisted, 1),
+    {1, 0} = esockd_limiter:consume(notexisted, 1),
     ok = esockd_limiter:stop().
 
 t_concurrent_consume(_) ->

--- a/test/esockd_limiter_SUITE.erl
+++ b/test/esockd_limiter_SUITE.erl
@@ -50,6 +50,23 @@ t_crud_limiter(_) ->
     undefined = esockd_limiter:lookup(bucket2),
     ok = esockd_limiter:stop().
 
+t_twice_create(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    ok = esockd_limiter:create(bucket1, 10),
+    #{name     := bucket1,
+      capacity := 10,
+      interval := 1,
+      tokens   := 10
+     } = esockd_limiter:lookup(bucket1),
+    {5, 0} = esockd_limiter:consume(bucket1, 5),
+    ok = esockd_limiter:create(bucket1, 100),
+    #{name     := bucket1,
+      capacity := 100,
+      interval := 1,
+      tokens   := 100
+     } = esockd_limiter:lookup(bucket1),
+    ok = esockd_limiter:stop().
+
 t_consume(_) ->
     {ok, _} = esockd_limiter:start_link(),
     ok = esockd_limiter:create(bucket, 10, 2),
@@ -69,6 +86,7 @@ t_consume(_) ->
     ok = timer:sleep(1020),
     #{tokens := 10} = esockd_limiter:lookup(bucket),
     {5, 0} = esockd_limiter:consume(bucket, 5),
+    {-1, 1000} = esockd_limiter:consume(notexisted, 1),
     ok = esockd_limiter:stop().
 
 t_handle_call(_) ->


### PR DESCRIPTION
**Bugfixes:**
- *esockd_limiter:* not pause on the nonexistent bucket
- *esockd_rate_limit:*  make the pause time more precise

**Features:**
- Add `get/set_manx_conn_rate` for dynamically managing Listener's connection rate

**Incompatible changes:**
- The get/set APIs will throw an error exception if the Listener does not exist