### PR TITLE
fix(proxy): avoid crashes in handling proxy protocol

### DIFF
--- a/test/esockd_proxy_protocol_SUITE.erl
+++ b/test/esockd_proxy_protocol_SUITE.erl
@@ -82,8 +82,22 @@ t_recv_pp_invalid(_) ->
     send_proxy_info(ProxyInfo = <<"Invalid PROXY\r\n">>),
     {error, {invalid_proxy_info, ProxyInfo}} = recv_proxy_info().
 
+t_recv_socket_error(_) ->
+    Reason = closed,
+    ok = send_socket_error(Reason),
+    {error, {recv_proxy_info_error, Reason}} = recv_proxy_info(),
+
+    ok = send_socket_closed(),
+    {error, {recv_proxy_info_error, tcp_closed}} = recv_proxy_info().
+
 send_proxy_info(ProxyInfo) ->
-    self() ! {esockd_transport, sock, ProxyInfo}, ok.
+    self() ! {tcp, sock, ProxyInfo}, ok.
+
+send_socket_error(Reason) ->
+    self() ! {tcp_error, sock, Reason}, ok.
+
+send_socket_closed() ->
+    self() ! {tcp_closed, sock}, ok.
 
 recv_proxy_info() ->
     esockd_proxy_protocol:recv(esockd_transport, sock, 1000).


### PR DESCRIPTION
We should handle the failure of receiving proxy info, otherwise, there will be some crash exceptions printed:

<img width="1380" alt="image" src="https://user-images.githubusercontent.com/13825269/104579175-99c77180-5696-11eb-8809-e687eddf201f.png">

In some generic scenarios, LB will keep establishing TCP connections to the server behind to test the live status of the server. In such scenarios, this error log will be printed constantly.