### PR TITLE
fix(hocon_schema): remove the opaqueness of esockd_peercert:peercert()

### DIFF
--- a/src/esockd_peercert.erl
+++ b/src/esockd_peercert.erl
@@ -20,7 +20,7 @@
 
 -export_type([peercert/0]).
 
--opaque(peercert() :: binary() | proplists:proplist()).
+-type(peercert() :: binary() | proplists:proplist()).
 
 -spec(subject(nossl | undefined | peercert()) -> undefined | binary()).
 subject(nossl)     -> undefined;


### PR DESCRIPTION
```
src/emqx_channel.erl
587
 260: Guard test is_binary(Peercert::'nossl' | 'undefined' | esockd_peercert:peercert()) breaks the opaqueness of its argument
588
 261: Guard test is_binary(Peercert::'nossl' | 'undefined' | esockd_peercert:peercert()) breaks the opaqueness of its argument
```