### PR TITLE
fix: SSL connection crashes with function_clause error after relup

### DIFF
--- a/src/esockd.appup.src
+++ b/src/esockd.appup.src
@@ -1,7 +1,7 @@
 %%-*- mode: erlang; -*-
 
-{"5.8.7",
-  [{"5.8.6",[{load_module,esockd_transport,brutal_purge,soft_purge,[]}]},
+{"5.8.8",
+  [{<<"5\\.8\\.[6-7]">>,[{load_module,esockd_transport,brutal_purge,soft_purge,[]}]},
    {<<"5\\.8\\.[4-5]">>,
     [{load_module,esockd_udp,brutal_purge,soft_purge,[]},
      {load_module,esockd_transport,brutal_purge,soft_purge,[]}
@@ -21,7 +21,7 @@
     ]},
    {<<".*">>, []}
   ],
-  [{"5.8.6",[{load_module,esockd_transport,brutal_purge,soft_purge,[]}]},
+  [{<<"5\\.8\\.[6-7]">>,[{load_module,esockd_transport,brutal_purge,soft_purge,[]}]},
    {<<"5\\.8\\.[4-5]">>,
     [{load_module,esockd_udp,brutal_purge,soft_purge,[]},
      {load_module,esockd_transport,brutal_purge,soft_purge,[]}

--- a/src/esockd_transport.erl
+++ b/src/esockd_transport.erl
@@ -349,6 +349,10 @@ ssl_upgrade_fun(SslOpts) ->
     {fun ?MODULE:ssl_upgrade/3, [SslOpts2, #{timeout => Timeout,
                                              gc_after_handshake => GCAfterHandshake}]}.
 
+%% NOTE: The first clause of the function `ssl_upgrade` (with an integer parameter
+%% `Timeout`) will be called by the running process after relup. So don't delete it.
+ssl_upgrade(Sock, SslOpts1, Timeout) when is_integer(Timeout) ->
+    ssl_upgrade(Sock, SslOpts1, #{timeout => Timeout, gc_after_handshake => false});
 ssl_upgrade(Sock, SslOpts1, #{timeout := Timeout,
                               gc_after_handshake := GCAfterHandshake}) ->
     try do_ssl_handshake(Sock, SslOpts1, Timeout) of


### PR DESCRIPTION
After release upgrade from e4.4.3 to e4.4.14, all the new TLS connections will fail to connect to emqx:

```
2023-01-17T12:44:16.319429+00:00 [error] crasher: initial call: emqx_connection:init/4, pid: <0.18564.56>, registered_name: [], error: {function_clause,[{esockd_transport,ssl_upgrade,[#Port<0.435075>,[{ciphers,["TLS_AES_256_GCM_SHA384","TLS_AES_128_GCM_SHA256","TLS_CHACHA20_POLY1305_SHA256","TLS_AES_128_CCM_SHA256","TLS_AES_128_CCM_8_SHA256","ECDHE-ECDSA-AES256-GCM-SHA384","ECDHE-RSA-AES256-GCM-SHA384","ECDHE-ECDSA-AES256-SHA384","ECDHE-RSA-AES256-SHA384","ECDHE-ECDSA-DES-CBC3-SHA","ECDH-ECDSA-AES256-GCM-SHA384","ECDH-RSA-AES256-GCM-SHA384","ECDH-ECDSA-AES256-SHA384","ECDH-RSA-AES256-SHA384","DHE-DSS-AES256-GCM-SHA384","DHE-DSS-AES256-SHA256","AES256-GCM-SHA384","AES256-SHA256","ECDHE-ECDSA-AES128-GCM-SHA256","ECDHE-RSA-AES128-GCM-SHA256","ECDHE-ECDSA-AES128-SHA256","ECDHE-RSA-AES128-SHA256","ECDH-ECDSA-AES128-GCM-SHA256","ECDH-RSA-AES128-GCM-SHA256","ECDH-ECDSA-AES128-SHA256","ECDH-RSA-AES128-SHA256","DHE-DSS-AES128-GCM-SHA256","DHE-DSS-AES128-SHA256","AES128-GCM-SHA256","AES128-SHA256","ECDHE-ECDSA-AES256-SHA","ECDHE-RSA-AES256-SHA","DHE-DSS-AES256-SHA","ECDH-ECDSA-AES256-SHA","ECDH-RSA-AES256-SHA","AES256-SHA","ECDHE-ECDSA-AES128-SHA","ECDHE-RSA-AES128-SHA","DHE-DSS-AES128-SHA","ECDH-ECDSA-AES128-SHA","ECDH-RSA-AES128-SHA","AES128-SHA"]},{depth,10},{keyfile,"etc/certs/key.pem"},{certfile,"etc/certs/cert.pem"},{cacertfile,"etc/certs/cacert.pem"},{verify,verify_peer},{fail_if_no_peer_cert,true},{reuse_sessions,true}],15000],[{file,"esockd_transport.erl"},{line,352}]},{esockd_transport,upgrade,2,[{file,"esockd_transport.erl"},{line,78}]},{emqx_connection,init,4,[{file,"emqx_connection.erl"},{line,262}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}, ancestors: [<0.2625.0>,<0.2624.0>,esockd_sup,<0.2179.0>], message_queue_len: 0, messages: [], links: [<0.2625.0>,#Port<0.435075>], dictionary: [], trap_exit: false, status: running, heap_size: 2586, stack_size: 29, reductions: 384; neighbours:
```

