### PR TITLE
fix: do not log error when proxy protocol header is not received

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ rebar3.crashdump
 *.swp
 .rebar3/
 rebar.lock
+TEST-*.xml

--- a/src/esockd.app.src
+++ b/src/esockd.app.src
@@ -1,7 +1,7 @@
 {application, esockd,
  [{description, "General Non-blocking TCP/SSL and UDP/DTLS Server"},
   {id, "esockd"},
-  {vsn, "5.9.5"},
+  {vsn, "5.9.6"},
   {modules, []},
   {registered, []},
   {applications, [kernel, stdlib, sasl, ssl]},

--- a/src/esockd.appup.src
+++ b/src/esockd.appup.src
@@ -1,22 +1,31 @@
 %%-*- mode: erlang; -*-
 
-{"5.9.5",
- [{"5.9.4",
+{"5.9.6",
+ [{"5.9.5",
    [ {load_module,esockd_transport,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
+   ]
+  },
+  {"5.9.4",
+   [ {load_module,esockd_transport,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.3",
    [ {load_module,esockd_transport,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.2",
    [ {load_module,esockd_udp,brutal_purge,soft_purge,[]}
    , {load_module,esockd_transport,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.1",
    [ {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
    , {load_module,esockd_udp,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.0",
@@ -27,6 +36,7 @@
    , {load_module,esockd_limiter,brutal_purge,soft_purge,[]}
    , {load_module,esockd_listener_sup,brutal_purge,soft_purge,[]}
    , {load_module,esockd_udp,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
    , {add_module,esockd_generic_limiter}
    ]
   },
@@ -34,20 +44,24 @@
  ],
  [{"5.9.4",
    [ {load_module,esockd_transport,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.3",
    [ {load_module,esockd_transport,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.2",
    [ {load_module,esockd_udp,brutal_purge,soft_purge,[]}
    , {load_module,esockd_transport,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.1",
     [ {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
     , {load_module,esockd_udp,brutal_purge,soft_purge,[]}
+    , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
     ]
   },
   {"5.9.0",
@@ -58,6 +72,7 @@
     , {load_module,esockd_limiter,brutal_purge,soft_purge,[]}
     , {load_module,esockd_listener_sup,brutal_purge,soft_purge,[]}
     , {load_module,esockd_udp,brutal_purge,soft_purge,[]}
+    , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
     , {delete_module,esockd_generic_limiter}
     ]
   },

--- a/src/esockd_proxy_protocol.erl
+++ b/src/esockd_proxy_protocol.erl
@@ -88,7 +88,9 @@ recv(Transport, Sock, Timeout) ->
         {tcp_error, _Sock, Reason} ->
             {error, {recv_proxy_info_error, Reason}};
         {tcp_closed, _Sock} ->
-            {error, {recv_proxy_info_error, tcp_closed}};
+            %% socket closed before any data is received
+            %% return an atom here to avoid error level logging
+            {error, proxy_proto_close};
         {_, _Sock, ProxyInfo} ->
             {error, {invalid_proxy_info, ProxyInfo}}
     after

--- a/test/esockd_proxy_protocol_SUITE.erl
+++ b/test/esockd_proxy_protocol_SUITE.erl
@@ -85,10 +85,10 @@ t_recv_pp_invalid(_) ->
 t_recv_socket_error(_) ->
     Reason = closed,
     ok = send_socket_error(Reason),
-    {error, {recv_proxy_info_error, Reason}} = recv_proxy_info(),
+    ?assertEqual({error, {recv_proxy_info_error, Reason}}, recv_proxy_info()),
 
     ok = send_socket_closed(),
-    {error, {recv_proxy_info_error, tcp_closed}} = recv_proxy_info().
+    ?assertEqual({error, proxy_proto_close}, recv_proxy_info()).
 
 send_proxy_info(ProxyInfo) ->
     self() ! {tcp, sock, ProxyInfo}, ok.


### PR DESCRIPTION
no error log if the socket is closed before any proxy protocol header is received