### PR TITLE
fix: do not log error when proxy protocol header is not received

### DIFF
--- a/src/esockd.app.src
+++ b/src/esockd.app.src
@@ -1,7 +1,7 @@
 {application, esockd,
  [{description, "General Non-blocking TCP/SSL and UDP/DTLS Server"},
   {id, "esockd"},
-  {vsn, "git"},
+  {vsn, "5.8.9"},
   {modules, []},
   {registered, []},
   {applications, [kernel, stdlib, sasl, ssl]},

--- a/src/esockd.appup.src
+++ b/src/esockd.appup.src
@@ -1,18 +1,27 @@
 %%-*- mode: erlang; -*-
 
-{"5.8.8",
-  [{<<"5\\.8\\.[6-7]">>,[{load_module,esockd_transport,brutal_purge,soft_purge,[]}]},
+{"5.8.9",
+  [{"5.8.8",
+    [{load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
+    ]},
+   {<<"5\\.8\\.[6-7]">>,
+    [{load_module,esockd_transport,brutal_purge,soft_purge,[]},
+     {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
+    ]},
    {<<"5\\.8\\.[4-5]">>,
     [{load_module,esockd_udp,brutal_purge,soft_purge,[]},
+     {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
      {load_module,esockd_transport,brutal_purge,soft_purge,[]}
     ]},
    {"5.8.3",
     [{load_module,esockd_udp,brutal_purge,soft_purge,[]},
+     {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
      {load_module, esockd_limiter, brutal_purge, soft_purge, []},
      {load_module,esockd_transport,brutal_purge,soft_purge,[]}
     ]},
    {<<"5\\.8\\.[0-2]">>,
     [{load_module,esockd_udp,brutal_purge,soft_purge,[]},
+     {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
      {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]},
      {load_module,esockd_dtls_listener,brutal_purge,soft_purge,[]},
      {load_module,esockd_transport,brutal_purge,soft_purge,[]},
@@ -21,18 +30,27 @@
     ]},
    {<<".*">>, []}
   ],
-  [{<<"5\\.8\\.[6-7]">>,[{load_module,esockd_transport,brutal_purge,soft_purge,[]}]},
+  [{"5.8.8",
+    [{load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
+    ]},
+   {<<"5\\.8\\.[6-7]">>,
+    [{load_module,esockd_transport,brutal_purge,soft_purge,[]},
+     {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
+    ]},
    {<<"5\\.8\\.[4-5]">>,
     [{load_module,esockd_udp,brutal_purge,soft_purge,[]},
+     {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
      {load_module,esockd_transport,brutal_purge,soft_purge,[]}
     ]},
    {"5.8.3",
     [{load_module,esockd_udp,brutal_purge,soft_purge,[]},
+     {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
      {load_module, esockd_limiter, brutal_purge, soft_purge, []},
      {load_module,esockd_transport,brutal_purge,soft_purge,[]}
     ]},
    {<<"5\\.8\\.[0-2]">>,
     [{load_module,esockd_udp,brutal_purge,soft_purge,[]},
+     {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
      {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]},
      {load_module,esockd_dtls_listener,brutal_purge,soft_purge,[]},
      {load_module,esockd_transport,brutal_purge,soft_purge,[]},

--- a/src/esockd_proxy_protocol.erl
+++ b/src/esockd_proxy_protocol.erl
@@ -88,7 +88,10 @@ recv(Transport, Sock, Timeout) ->
         {tcp_error, _Sock, Reason} ->
             {error, {recv_proxy_info_error, Reason}};
         {tcp_closed, _Sock} ->
-            {error, {recv_proxy_info_error, tcp_closed}};
+            %% Socket closed before any data is received.
+            %% Here we return an atom here to avoid error level logging.
+            %% See the from the connection_crashed function in esockd_connection_sup.erl.
+            {error, proxy_proto_close};
         {_, _Sock, ProxyInfo} ->
             {error, {invalid_proxy_info, ProxyInfo}}
     after

--- a/test/esockd_proxy_protocol_SUITE.erl
+++ b/test/esockd_proxy_protocol_SUITE.erl
@@ -85,10 +85,10 @@ t_recv_pp_invalid(_) ->
 t_recv_socket_error(_) ->
     Reason = closed,
     ok = send_socket_error(Reason),
-    {error, {recv_proxy_info_error, Reason}} = recv_proxy_info(),
+    ?assertEqual({error, {recv_proxy_info_error, Reason}}, recv_proxy_info()),
 
     ok = send_socket_closed(),
-    {error, {recv_proxy_info_error, tcp_closed}} = recv_proxy_info().
+    ?assertEqual({error, proxy_proto_close}, recv_proxy_info()).
 
 send_proxy_info(ProxyInfo) ->
     self() ! {tcp, sock, ProxyInfo}, ok.


### PR DESCRIPTION
Port the https://github.com/emqx/esockd/pull/171 to 5.8.x (used by emqx version 4.4)