### PR TITLE
Log error when recv proxy info timeout

### DIFF
--- a/src/esockd.app.src
+++ b/src/esockd.app.src
@@ -1,7 +1,7 @@
 {application, esockd,
  [{description, "General Non-blocking TCP/SSL and UDP/DTLS Server"},
   {id, "esockd"},
-  {vsn, "5.8.9"},
+  {vsn, "5.8.10"},
   {modules, []},
   {registered, []},
   {applications, [kernel, stdlib, sasl, ssl]},

--- a/src/esockd.appup.src
+++ b/src/esockd.appup.src
@@ -1,16 +1,7 @@
 %%-*- mode: erlang; -*-
 
 {"5.8.10",
-  [{"5.8.9",
-    [{add_module,esockd_utils},
-     {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
-    ]},
-   {"5.8.8",
-    [{add_module,esockd_utils},
-     {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
-     {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
-    ]},
-   {<<"5\\.8\\.[6-7]">>,
+  [{<<"5\\.8\\.[6-9]">>,
     [{add_module,esockd_utils},
      {load_module,esockd_transport,brutal_purge,soft_purge,[]},
      {load_module,esockd_acceptor,brutal_purge,soft_purge,[]},
@@ -28,7 +19,7 @@
      {load_module,esockd_udp,brutal_purge,soft_purge,[]},
      {load_module,esockd_acceptor,brutal_purge,soft_purge,[]},
      {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
-     {load_module, esockd_limiter, brutal_purge, soft_purge, []},
+     {load_module,esockd_limiter, brutal_purge, soft_purge, []},
      {load_module,esockd_transport,brutal_purge,soft_purge,[]}
     ]},
    {<<"5\\.8\\.[0-2]">>,
@@ -44,15 +35,7 @@
     ]},
    {<<".*">>, []}
   ],
-  [{"5.8.9",
-    [{load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
-     {delete_module,esockd_utils}]},
-   {"5.8.8",
-    [{load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
-     {load_module,esockd_acceptor,brutal_purge,soft_purge,[]},
-     {delete_module,esockd_utils}
-    ]},
-   {<<"5\\.8\\.[6-7]">>,
+  [{<<"5\\.8\\.[6-9]">>,
     [{load_module,esockd_transport,brutal_purge,soft_purge,[]},
      {load_module,esockd_acceptor,brutal_purge,soft_purge,[]},
      {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
@@ -69,7 +52,7 @@
     [{load_module,esockd_udp,brutal_purge,soft_purge,[]},
      {load_module,esockd_acceptor,brutal_purge,soft_purge,[]},
      {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
-     {load_module, esockd_limiter, brutal_purge, soft_purge, []},
+     {load_module,esockd_limiter, brutal_purge, soft_purge, []},
      {load_module,esockd_transport,brutal_purge,soft_purge,[]},
      {delete_module,esockd_utils}
     ]},

--- a/src/esockd.appup.src
+++ b/src/esockd.appup.src
@@ -2,32 +2,38 @@
 
 {"5.8.10",
   [{"5.8.9",
-    [{load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
+    [{add_module,esockd_utils},
+     {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
     ]},
    {"5.8.8",
-    [{load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
+    [{add_module,esockd_utils},
+     {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
      {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
     ]},
    {<<"5\\.8\\.[6-7]">>,
-    [{load_module,esockd_transport,brutal_purge,soft_purge,[]},
+    [{add_module,esockd_utils},
+     {load_module,esockd_transport,brutal_purge,soft_purge,[]},
      {load_module,esockd_acceptor,brutal_purge,soft_purge,[]},
      {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
     ]},
    {<<"5\\.8\\.[4-5]">>,
-    [{load_module,esockd_udp,brutal_purge,soft_purge,[]},
+    [{add_module,esockd_utils},
+     {load_module,esockd_udp,brutal_purge,soft_purge,[]},
      {load_module,esockd_acceptor,brutal_purge,soft_purge,[]},
      {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
      {load_module,esockd_transport,brutal_purge,soft_purge,[]}
     ]},
    {"5.8.3",
-    [{load_module,esockd_udp,brutal_purge,soft_purge,[]},
+    [{add_module,esockd_utils},
+     {load_module,esockd_udp,brutal_purge,soft_purge,[]},
      {load_module,esockd_acceptor,brutal_purge,soft_purge,[]},
      {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
      {load_module, esockd_limiter, brutal_purge, soft_purge, []},
      {load_module,esockd_transport,brutal_purge,soft_purge,[]}
     ]},
    {<<"5\\.8\\.[0-2]">>,
-    [{load_module,esockd_udp,brutal_purge,soft_purge,[]},
+    [{add_module,esockd_utils},
+     {load_module,esockd_udp,brutal_purge,soft_purge,[]},
      {load_module,esockd_acceptor,brutal_purge,soft_purge,[]},
      {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
      {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]},
@@ -39,29 +45,33 @@
    {<<".*">>, []}
   ],
   [{"5.8.9",
-    [{load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
-    ]},
+    [{load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
+     {delete_module,esockd_utils}]},
    {"5.8.8",
     [{load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
-     {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
+     {load_module,esockd_acceptor,brutal_purge,soft_purge,[]},
+     {delete_module,esockd_utils}
     ]},
    {<<"5\\.8\\.[6-7]">>,
     [{load_module,esockd_transport,brutal_purge,soft_purge,[]},
      {load_module,esockd_acceptor,brutal_purge,soft_purge,[]},
-     {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
+     {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
+     {delete_module,esockd_utils}
     ]},
    {<<"5\\.8\\.[4-5]">>,
     [{load_module,esockd_udp,brutal_purge,soft_purge,[]},
      {load_module,esockd_acceptor,brutal_purge,soft_purge,[]},
      {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
-     {load_module,esockd_transport,brutal_purge,soft_purge,[]}
+     {load_module,esockd_transport,brutal_purge,soft_purge,[]},
+     {delete_module,esockd_utils}
     ]},
    {"5.8.3",
     [{load_module,esockd_udp,brutal_purge,soft_purge,[]},
      {load_module,esockd_acceptor,brutal_purge,soft_purge,[]},
      {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
      {load_module, esockd_limiter, brutal_purge, soft_purge, []},
-     {load_module,esockd_transport,brutal_purge,soft_purge,[]}
+     {load_module,esockd_transport,brutal_purge,soft_purge,[]},
+     {delete_module,esockd_utils}
     ]},
    {<<"5\\.8\\.[0-2]">>,
     [{load_module,esockd_udp,brutal_purge,soft_purge,[]},
@@ -71,7 +81,8 @@
      {load_module,esockd_dtls_listener,brutal_purge,soft_purge,[]},
      {load_module,esockd_transport,brutal_purge,soft_purge,[]},
      {load_module,esockd_peercert,brutal_purge,soft_purge,[]},
-     {load_module,esockd,brutal_purge,soft_purge,[]}
+     {load_module,esockd,brutal_purge,soft_purge,[]},
+     {delete_module,esockd_utils}
     ]},
    {<<".*">>, []}
   ]

--- a/src/esockd.appup.src
+++ b/src/esockd.appup.src
@@ -1,7 +1,10 @@
 %%-*- mode: erlang; -*-
 
-{"5.8.9",
-  [{"5.8.8",
+{"5.8.10",
+  [{"5.8.9",
+    [{load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
+    ]},
+   {"5.8.8",
     [{load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
      {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
     ]},
@@ -35,7 +38,10 @@
     ]},
    {<<".*">>, []}
   ],
-  [{"5.8.8",
+  [{"5.8.9",
+    [{load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
+    ]},
+   {"5.8.8",
     [{load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]},
      {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
     ]},

--- a/src/esockd_acceptor.erl
+++ b/src/esockd_acceptor.erl
@@ -159,7 +159,7 @@ accepting(info, {inet_async, LSock, Ref, {error, Reason}},
           State = #state{lsock = LSock, sockname = Sockname, accept_ref = Ref})
     when Reason =:= emfile; Reason =:= enfile ->
     error_logger:error_msg("Accept error on ~s: ~s",
-                           [esockd:format(Sockname), explain_posix(Reason)]),
+                           [esockd:format(Sockname), esockd_utils:explain_posix(Reason)]),
     {next_state, suspending, State, 1000};
 
 accepting(info, {inet_async, LSock, Ref, {error, Reason}},
@@ -194,8 +194,3 @@ rate_limit(State = #state{conn_limiter = Limiter}) ->
 
 eval_tune_socket_fun({Fun, Args1}, Sock) ->
     apply(Fun, [Sock|Args1]).
-
-explain_posix(emfile) ->
-    "EMFILE (Too many open files)";
-explain_posix(enfile) ->
-    "ENFILE (File table overflow)".

--- a/src/esockd_proxy_protocol.erl
+++ b/src/esockd_proxy_protocol.erl
@@ -25,6 +25,16 @@
 -export([parse_v1/2, parse_v2/4, parse_pp2_tlv/2, parse_pp2_ssl/1]).
 -endif.
 
+-define(ERR_MSG_IN_PP_MODE, "The listener ~s is working in proxy protocol mode, but ").
+
+-define(LOG(LEVEL, Format, Args), logger:log(LEVEL, "[~s] " ++ Format, [?MODULE | Args])).
+-define(LOG_PP_ERROR(Format, Args, Sock),
+        ?LOG(error, ?ERR_MSG_IN_PP_MODE ++ Format, [
+            case Transport:sockname(Sock) of
+                {ok, SockName} -> esockd:format(SockName);
+                _ -> unknown
+            end| Args])).
+
 %% Protocol Command
 -define(LOCAL, 16#0).
 -define(PROXY, 16#1).
@@ -83,20 +93,24 @@ recv(Transport, Sock, Timeout) ->
                     Transport:setopts(Sock, OriginOpts),
                     parse_v2(Cmd, Trans, ProxyInfo, #proxy_socket{inet = inet_family(AF), socket = Sock});
                 {error, Reason} ->
-                    {error, {recv_proxy_info_error, Reason}}
+                    ?LOG_PP_ERROR("some errors occurred while waiting for proxy info: ~p", [Reason], Sock),
+                    {error, recv_proxy_info_error}
             end;
         {tcp_error, _Sock, Reason} ->
-            {error, {recv_proxy_info_error, Reason}};
+            ?LOG_PP_ERROR("got a TCP error while waiting for proxy info: ~p", [Reason], Sock),
+            {error, recv_proxy_info_error};
         {tcp_closed, _Sock} ->
             %% Socket closed before any data is received.
             %% Here we return an atom here to avoid error level logging.
             %% See the from the connection_crashed function in esockd_connection_sup.erl.
             {error, proxy_proto_close};
         {_, _Sock, ProxyInfo} ->
-            {error, {invalid_proxy_info, ProxyInfo}}
+            ?LOG_PP_ERROR("got invalid proxy info: ~p", [ProxyInfo], Sock),
+            {error, invalid_proxy_info}
     after
         Timeout ->
-            {error, {proxy_proto_timeout, Timeout}}
+            ?LOG_PP_ERROR("timed out while waiting for proxy info", [], Sock),
+            {error, proxy_proto_timeout}
     end.
 
 parse_v1(ProxyInfo, ProxySock) ->

--- a/src/esockd_proxy_protocol.erl
+++ b/src/esockd_proxy_protocol.erl
@@ -96,7 +96,7 @@ recv(Transport, Sock, Timeout) ->
             {error, {invalid_proxy_info, ProxyInfo}}
     after
         Timeout ->
-            {error, proxy_proto_timeout}
+            {error, {proxy_proto_timeout, Timeout}}
     end.
 
 parse_v1(ProxyInfo, ProxySock) ->

--- a/src/esockd_proxy_protocol.erl
+++ b/src/esockd_proxy_protocol.erl
@@ -27,13 +27,13 @@
 
 -define(ERR_MSG_IN_PP_MODE, "The listener ~s is working in proxy protocol mode, but ").
 
--define(LOG(LEVEL, Format, Args), logger:log(LEVEL, "[~s] " ++ Format, [?MODULE | Args])).
--define(LOG_PP_ERROR(Format, Args, Sock),
-        ?LOG(error, ?ERR_MSG_IN_PP_MODE ++ Format, [
+-define(LOG(LEVEL, FROMAT, ARGS), logger:log(LEVEL, "[~s] " ++ FROMAT, [?MODULE | ARGS])).
+-define(LOG_PP_ERROR(FROMAT, ARGS, Sock),
+        ?LOG(error, ?ERR_MSG_IN_PP_MODE ++ FROMAT, [
             case Transport:sockname(Sock) of
                 {ok, SockName} -> esockd:format(SockName);
                 _ -> unknown
-            end| Args])).
+            end | explain_posix_errors(ARGS)])).
 
 %% Protocol Command
 -define(LOCAL, 16#0).
@@ -93,11 +93,11 @@ recv(Transport, Sock, Timeout) ->
                     Transport:setopts(Sock, OriginOpts),
                     parse_v2(Cmd, Trans, ProxyInfo, #proxy_socket{inet = inet_family(AF), socket = Sock});
                 {error, Reason} ->
-                    ?LOG_PP_ERROR("some errors occurred while waiting for proxy info: ~p", [Reason], Sock),
+                    ?LOG_PP_ERROR("got an error while receiving proxy_protocol header, reason=~p", [Reason], Sock),
                     {error, recv_proxy_info_error}
             end;
         {tcp_error, _Sock, Reason} ->
-            ?LOG_PP_ERROR("got a TCP error while waiting for proxy info: ~p", [Reason], Sock),
+            ?LOG_PP_ERROR("got an error while waiting for proxy_protocol header, reason=~p", [Reason], Sock),
             {error, recv_proxy_info_error};
         {tcp_closed, _Sock} ->
             %% Socket closed before any data is received.
@@ -105,11 +105,11 @@ recv(Transport, Sock, Timeout) ->
             %% See the from the connection_crashed function in esockd_connection_sup.erl.
             {error, proxy_proto_close};
         {_, _Sock, ProxyInfo} ->
-            ?LOG_PP_ERROR("got invalid proxy info: ~p", [ProxyInfo], Sock),
+            ?LOG_PP_ERROR("received invalid proxy_protocol header, raw_bytes=~p", [ProxyInfo], Sock),
             {error, invalid_proxy_info}
     after
         Timeout ->
-            ?LOG_PP_ERROR("timed out while waiting for proxy info", [], Sock),
+            ?LOG_PP_ERROR("timed out while waiting for proxy_protocol header", [], Sock),
             {error, proxy_proto_timeout}
     end.
 
@@ -225,3 +225,5 @@ inet_family(?UNIX)   -> unix.
 bool(1) -> true;
 bool(_) -> false.
 
+explain_posix_errors(Args) ->
+    [esockd_utils:explain_posix(A) || A <- Args].

--- a/src/esockd_utils.erl
+++ b/src/esockd_utils.erl
@@ -1,0 +1,52 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(esockd_utils).
+
+-export([explain_posix/1]).
+
+explain_posix(eacces) -> "EACCES (Permission denied)";
+explain_posix(eagain) -> "EAGAIN (Resource temporarily unavailable)";
+explain_posix(ebadf) -> "EBADF (Bad file number)";
+explain_posix(ebusy) -> "EBUSY (File busy)";
+explain_posix(edquot) -> "EDQUOT (Disk quota exceeded)";
+explain_posix(eexist) -> "EEXIST (File already exists)";
+explain_posix(efault) -> "EFAULT (Bad address in system call argument)";
+explain_posix(efbig) -> "EFBIG (File too large)";
+explain_posix(eintr) -> "EINTR (Interrupted system call)";
+explain_posix(einval) -> "EINVAL (Invalid argument argument file/socket)";
+explain_posix(eio) -> "EIO (I/O error)";
+explain_posix(eisdir) -> "EISDIR (Illegal operation on a directory)";
+explain_posix(eloop) -> "ELOOP (Too many levels of symbolic links)";
+explain_posix(emfile) -> "EMFILE (Too many open files)";
+explain_posix(emlink) -> "EMLINK (Too many links)";
+explain_posix(enametoolong) -> "ENAMETOOLONG (Filename too long)";
+explain_posix(enfile) -> "ENFILE (File table overflow)";
+explain_posix(enodev) -> "ENODEV (No such device)";
+explain_posix(enoent) -> "ENOENT (No such file or directory)";
+explain_posix(enomem) -> "ENOMEM (Not enough memory)";
+explain_posix(enospc) -> "ENOSPC (No space left on device)";
+explain_posix(enotblk) -> "ENOTBLK (Block device required)";
+explain_posix(enotdir) -> "ENOTDIR (Not a directory)";
+explain_posix(enotsup) -> "ENOTSUP (Operation not supported)";
+explain_posix(enxio) -> "ENXIO (No such device or address)";
+explain_posix(eperm) -> "EPERM (Not owner)";
+explain_posix(epipe) -> "EPIPE (Broken pipe)";
+explain_posix(erofs) -> "EROFS (Read-only file system)";
+explain_posix(espipe) -> "ESPIPE (Invalid seek)";
+explain_posix(esrch) -> "ESRCH (No such process)";
+explain_posix(estale) -> "ESTALE (Stale remote file handle)";
+explain_posix(exdev) -> "EXDEV (Cross-domain link)";
+explain_posix(NotPosix) -> NotPosix.


### PR DESCRIPTION
Before the change:
```
2023-04-20T14:56:51.671735+08:00 [error] supervisor: 'esockd_connection_sup - <0.2537.0>', errorContext: connection_shutdown, reason: {invalid_proxy_info,<<"f\n">>}, offender: [{pid,<0.3192.0>},{name,connection},{mfargs,{emqx_connection,start_link,[[{listener_id,<<"mqtt:tcp:external">>},{deflate_options,[]},{max_conn_rate,1000},{active_n,100},{zone,external},{proxy_address_header,<<>>},{proxy_port_header,<<>>},{supported_subprotocols,[]}]]}}]

2023-04-20T14:57:01.348275+08:00 [error] supervisor: 'esockd_connection_sup - <0.2537.0>', errorContext: connection_shutdown, reason: {proxy_proto_timeout,5000}, offender: [{pid,<0.3194.0>},{name,connection},{mfargs,{emqx_connection,start_link,[[{listener_id,<<"mqtt:tcp:external">>},{deflate_options,[]},{max_conn_rate,1000},{active_n,100},{zone,external},{proxy_address_header,<<>>},{proxy_port_header,<<>>},{supported_subprotocols,[]}]]}}]
```

After the change:
```
2023-04-20T18:07:06.180134+08:00 [error] [esockd_proxy_protocol] The listener 127.0.0.1:8883 is working in proxy protocol mode, but received invalid proxy_protocol header, raw_bytes=<<"f\n">>

2023-04-20T18:10:17.205436+08:00 [error] [esockd_proxy_protocol] The listener 127.0.0.1:8883 is working in proxy protocol mode, but timed out while waiting for proxy_protocol header
```
