### PR TITLE
0915 do not log tls at error level

### DIFF
--- a/src/esockd.appup.src
+++ b/src/esockd.appup.src
@@ -3,24 +3,28 @@
 {"5.9.7",
  [{"5.9.6",
    [ {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.5",
    [ {load_module,esockd_transport,brutal_purge,soft_purge,[]}
    , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
    , {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.4",
    [ {load_module,esockd_transport,brutal_purge,soft_purge,[]}
    , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
-  , {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.3",
    [ {load_module,esockd_transport,brutal_purge,soft_purge,[]}
    , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
    , {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.2",
@@ -28,12 +32,14 @@
    , {load_module,esockd_transport,brutal_purge,soft_purge,[]}
    , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
    , {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.1",
    [ {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
    , {load_module,esockd_udp,brutal_purge,soft_purge,[]}
    , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.0",
@@ -46,30 +52,35 @@
    , {load_module,esockd_udp,brutal_purge,soft_purge,[]}
    , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
    , {add_module,esockd_generic_limiter}
+   , {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]}
    ]
   },
   {<<".*">>, []}
  ],
  [{"5.9.6",
    [ {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.5",
    [ {load_module,esockd_transport,brutal_purge,soft_purge,[]}
    , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
    , {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.4",
    [ {load_module,esockd_transport,brutal_purge,soft_purge,[]}
    , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
    , {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.3",
    [ {load_module,esockd_transport,brutal_purge,soft_purge,[]}
    , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
    , {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.2",
@@ -77,12 +88,14 @@
    , {load_module,esockd_transport,brutal_purge,soft_purge,[]}
    , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
    , {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
+   , {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]}
    ]
   },
   {"5.9.1",
     [ {load_module,esockd_acceptor,brutal_purge,soft_purge,[]}
     , {load_module,esockd_udp,brutal_purge,soft_purge,[]}
     , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
+    , {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]}
     ]
   },
   {"5.9.0",
@@ -95,6 +108,7 @@
     , {load_module,esockd_udp,brutal_purge,soft_purge,[]}
     , {load_module,esockd_proxy_protocol,brutal_purge,soft_purge,[]}
     , {delete_module,esockd_generic_limiter}
+    , {load_module,esockd_connection_sup,brutal_purge,soft_purge,[]}
     ]
   },
   {<<".*">>, []}

--- a/test/echo_server.erl
+++ b/test/echo_server.erl
@@ -39,6 +39,8 @@ loop(Transport, Sock) ->
             %%io:format("RECV from ~s: ~s~n", [esockd:format(Peername), Data]),
             Transport:send(Sock, Data),
             loop(Transport, Sock);
+        {shutdown, Reason} ->
+            exit({shutdown, Reason});
         {error, Reason} ->
             exit({shutdown, Reason})
 	end.


### PR DESCRIPTION
Lower `ssl_error` shutdown log to `info` level.
Also support `shutdown_count` in shutdown reasons, then log it at `info` level.

For unidentified shutdowns and uncaught exceptions, we continue log at error level.