### PR TITLE
fix(setopts): pass only changed socket options to `setops/2`

### DIFF
--- a/src/esockd.erl
+++ b/src/esockd.erl
@@ -106,8 +106,10 @@
 
 -type(host() :: inet:ip_address() | string()).
 -type(listen_on() :: inet:port_number() | {host(), inet:port_number()}).
--type ssl_options() :: [{handshake_timeout, pos_integer()} | ssl_option()].
--type dtls_options() :: [{handshake_timeout, pos_integer()} | ssl_option()].
+-type ssl_options() :: [ssl_custom_option() | ssl_option()].
+-type dtls_options() :: [ssl_custom_option() | ssl_option()].
+-type ssl_custom_option() :: {handshake_timeout, pos_integer()}
+                           | {gc_after_handshake, boolean()}.
 -type listener_ref() :: {proto(), listen_on()}.
 
 %%--------------------------------------------------------------------

--- a/src/esockd.erl
+++ b/src/esockd.erl
@@ -65,6 +65,7 @@
 
 %% Utility functions
 -export([ merge_opts/2
+        , changed_opts/2
         , parse_opt/1
         , ulimit/0
         , fixaddr/1
@@ -301,6 +302,19 @@ merge_opt(tcp_options, Opts1, Opts2) -> merge_opts(Opts1, Opts2);
 merge_opt(udp_options, Opts1, Opts2) -> merge_opts(Opts1, Opts2);
 merge_opt(dtls_options, Opts1, Opts2) -> merge_opts(Opts1, Opts2);
 merge_opt(_, _Opt1, Opt2) -> Opt2.
+
+-spec changed_opts(proplists:proplist(), proplists:proplist())
+      -> proplists:proplist().
+changed_opts(Opts, OptsRef) ->
+    lists:filter(
+        fun(Opt) ->
+            [Name] = proplists:get_keys([Opt]),
+            Value = proplists:get_value(Name, [Opt]),
+            ValueRef = proplists:get_value(Name, OptsRef),
+            ValueRef =/= Value orelse ValueRef == undefined
+        end,
+        Opts
+    ).
 
 %% @doc Parse option.
 parse_opt(Options) ->

--- a/src/esockd_dtls_listener.erl
+++ b/src/esockd_dtls_listener.erl
@@ -112,10 +112,15 @@ init({Proto, ListenOn, Opts}) ->
     end.
 
 dltsopts(Opts) ->
-    proplists:delete(
-     handshake_timeout,
-     proplists:get_value(dtls_options, Opts, [])
-    ).
+    %% Filter out `esockd:ssl_custom_option()`, otherwise DTLS listener will
+    %% fail to start.
+    DTLSOpts = lists:foldl(
+        fun proplists:delete/2,
+        proplists:get_value(dtls_options, Opts, []),
+        [handshake_timeout, gc_after_handshake]
+    ),
+    SockOpts = proplists:get_value(udp_options, Opts, []),
+    SockOpts ++ DTLSOpts.
 
 port(Port) when is_integer(Port) -> Port;
 port({_Addr, Port}) -> Port.

--- a/src/esockd_listener_sup.erl
+++ b/src/esockd_listener_sup.erl
@@ -125,7 +125,7 @@ set_options(ListenerRef, Sup, Opts) ->
             %% Restore previous options
             _ = esockd_server:set_listener_prop(ListenerRef, options, OptsWas),
             ok = esockd_connection_sup:set_options(ConnSup, OptsWas),
-            ok = Listener:set_options(ListenerPid, OptsWas),
+            %% Listener has failed to set options, no need to restore
             Error
     end,
     ok = restart_acceptor_sup(ListenerRef, Sup),

--- a/test/const_server.erl
+++ b/test/const_server.erl
@@ -1,0 +1,45 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(const_server).
+
+-export([start_link/3]).
+
+%% Callbacks
+-export([init/3, loop/3]).
+
+start_link(Transport, RawSock, Resp) ->
+	{ok, spawn_link(?MODULE, init, [Transport, RawSock, Resp])}.
+
+init(Transport, RawSock, Resp) ->
+    case Transport:wait(RawSock) of
+        {ok, Sock} ->
+            loop(Transport, Sock, Resp);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+loop(Transport, Sock, Resp) ->
+	case Transport:recv(Sock, 0) of
+        {ok, _Data} ->
+            Transport:send(Sock, Resp),
+            loop(Transport, Sock, Resp);
+        {shutdown, Reason} ->
+            exit({shutdown, Reason});
+        {error, Reason} ->
+            exit({shutdown, Reason})
+	end.
+

--- a/test/esockd_SUITE.erl
+++ b/test/esockd_SUITE.erl
@@ -88,9 +88,7 @@ t_udp_child_spec(_) ->
      } = Spec.
 
 t_open_dtls(Config) ->
-    DtlsOpts = [{mode, binary},
-                {reuseaddr, true},
-                {certfile, esockd_ct:certfile(Config)},
+    DtlsOpts = [{certfile, esockd_ct:certfile(Config)},
                 {keyfile,  esockd_ct:keyfile(Config)},
                 {verify, verify_none}
                ],
@@ -245,14 +243,15 @@ t_get_current_connections(Config) ->
     ?assertEqual(0, esockd:get_current_connections({echo, 7000})),
     ok = esockd:close(echo, 7000),
 
-    DtlsOpts = [{mode, binary},
-                {reuseaddr, true},
-                {certfile, esockd_ct:certfile(Config)},
+    UdpOpts = [{mode, binary}, {reuseaddr, true}],
+    DtlsOpts = [{certfile, esockd_ct:certfile(Config)},
                 {keyfile, esockd_ct:keyfile(Config)},
                 {verify, verify_none}
                ],
     ClientOpts = [binary, {protocol, dtls}, {verify, verify_none}],
-    {ok, _LSup1} = esockd:open_dtls(dtls_echo, 7000, [{dtls_options, DtlsOpts}], {dtls_echo_server, start_link, []}),
+    {ok, _LSup1} = esockd:open_dtls(dtls_echo, 7000,
+                                    [{dtls_options, DtlsOpts}, {udp_options, UdpOpts}],
+                                    {dtls_echo_server, start_link, []}),
     {ok, DtlsSock1} = ssl:connect({127,0,0,1}, 7000, ClientOpts, 5000),
     {ok, DtlsSock2} = ssl:connect({127,0,0,1}, 7000, ClientOpts, 5000),
     timer:sleep(10),
@@ -282,14 +281,15 @@ t_get_shutdown_count(Config) ->
     ?assertEqual([{closed, 2}], esockd:get_shutdown_count({echo, 7000})),
     ok = esockd:close(echo, 7000),
 
-    DtlsOpts = [{mode, binary},
-                {reuseaddr, true},
-                {certfile, esockd_ct:certfile(Config)},
+    UdpOpts = [{mode, binary}, {reuseaddr, true}],
+    DtlsOpts = [{certfile, esockd_ct:certfile(Config)},
                 {keyfile, esockd_ct:keyfile(Config)},
                 {verify, verify_none}
                ],
     ClientOpts = [binary, {protocol, dtls}, {verify, verify_none}],
-    {ok, _LSup1} = esockd:open_dtls(dtls_echo, 7000, [{dtls_options, DtlsOpts}], {dtls_echo_server, start_link, []}),
+    {ok, _LSup1} = esockd:open_dtls(dtls_echo, 7000,
+                                    [{dtls_options, DtlsOpts}, {udp_options, UdpOpts}],
+                                    {dtls_echo_server, start_link, []}),
     {ok, DtlsSock1} = ssl:connect({127,0,0,1}, 7000, ClientOpts, 5000),
     {ok, DtlsSock2} = ssl:connect({127,0,0,1}, 7000, ClientOpts, 5000),
     ok = ssl:close(DtlsSock1),

--- a/test/esockd_SUITE.erl
+++ b/test/esockd_SUITE.erl
@@ -447,6 +447,16 @@ t_merge_opts(_) ->
              ],
     ?assertEqual(Result, esockd:merge_opts(Opts1, Opts2)).
 
+t_changed_opts(_) ->
+    Opts1 = [ binary, {acceptors, 8}, {tune_buffer, true}
+            , {ssl_options, [{keyfile, "key.pem"}, {certfile, "cert.pem"}]}
+            ],
+    Opts2 = [ binary, inet6, {acceptors, 16}
+            , {ssl_options, [{keyfile, "key.pem"}, {certfile, "cert.pem"}]}
+            ],
+    Result = [inet6, {acceptors, 16}],
+    ?assertEqual(Result, esockd:changed_opts(Opts2, Opts1)).
+
 t_parse_opt(_) ->
     Opts = [{acceptors, 10}, {tune_buffer, true}, {proxy_protocol, true}, {ssl_options, []}],
     ?assertEqual(Opts, esockd:parse_opt([{badopt1, val1}, {badopt2, val2}|Opts])).

--- a/test/esockd_SUITE.erl
+++ b/test/esockd_SUITE.erl
@@ -33,16 +33,16 @@ end_per_suite(_Config) ->
     application:stop(esockd).
 
 t_open_close(_) ->
-    {ok, _LSup} = esockd:open(echo, {"127.0.0.1", 3000}, [binary, {packet, raw}],
-                              {echo_server, start_link, []}),
+    {ok, _LSup} = esockd:open(echo, {"127.0.0.1", 3000},
+                              [binary, {packet, raw}, {connection_mfargs, echo_server}]),
     {ok, Sock} = gen_tcp:connect("127.0.0.1", 3000, [binary, {active, false}]),
     ok = gen_tcp:send(Sock, <<"Hello">>),
     {ok, <<"Hello">>} = gen_tcp:recv(Sock, 0),
     ok = esockd:close(echo, {"127.0.0.1", 3000}).
 
 t_reopen(_) ->
-    {ok, _LSup} = esockd:open(echo, {"127.0.0.1", 3000}, [binary, {packet, raw}],
-                              {echo_server, start_link, []}),
+    {ok, _LSup} = esockd:open(echo, {"127.0.0.1", 3000},
+                              [binary, {packet, raw}, {connection_mfargs, echo_server}]),
     {ok, Sock1} = gen_tcp:connect("127.0.0.1", 3000, [{active, false}]),
     ok = gen_tcp:send(Sock1, <<"Hello">>),
     timer:sleep(10),
@@ -53,8 +53,9 @@ t_reopen(_) ->
     ok = esockd:close(echo, {"127.0.0.1", 3000}).
 
 t_reopen_1(_) ->
-    {ok, _LSup} = esockd:open(echo, 7000, [{max_connections, 4}, {acceptors, 4}],
-                              {echo_server, start_link, []}),
+    {ok, _LSup} = esockd:open(echo, 7000,
+                              [{max_connections, 4}, {acceptors, 4},
+                               {connection_mfargs, echo_server}]),
     timer:sleep(10),
     ok = esockd:reopen({echo, 7000}),
     ?assertEqual(4, esockd:get_max_connections({echo, 7000})),
@@ -63,7 +64,8 @@ t_reopen_1(_) ->
 
 t_reopen_fail(_) ->
     LPort = 4001,
-    {ok, _LSup} = esockd:open(echo, LPort, [{acceptors, 4}], {echo_server, start_link, []}),
+    {ok, _LSup} = esockd:open(echo, LPort,
+                              [{acceptors, 4}, {connection_mfargs, {echo_server, start_link}}]),
     {error, not_found} = esockd:reopen({echo, 5000}),
     ?assertEqual(4, esockd:get_acceptors({echo, LPort})),
     {ok, Sock} = gen_tcp:connect({127,0,0,1}, LPort, [binary, {active, false}]),
@@ -72,14 +74,17 @@ t_reopen_fail(_) ->
     ok = esockd:close(echo, LPort).
 
 t_open_udp(_) ->
-    {ok, _} = esockd:open_udp(echo, 5678, [], {udp_echo_server, start_link, []}),
+    {ok, _} = esockd:open_udp(echo, 5678,
+                              [{connection_mfargs, {udp_echo_server, start_link}}]),
     {ok, Sock} = gen_udp:open(0, [binary, {active, false}]),
     ok = gen_udp:send(Sock, {127,0,0,1}, 5678, <<"Hi">>),
     {ok, {_Addr, 5678, <<"Hi">>}} = gen_udp:recv(Sock, 0),
     ok = esockd:close(echo, 5678).
 
 t_udp_child_spec(_) ->
-    Spec = esockd:udp_child_spec(echo, 5000, [], {udp_echo_server, start_link, []}),
+    MFA = {udp_echo_server, start_link, []},
+    Spec = esockd:udp_child_spec(echo, 5000, [{connection_mfargs, MFA}]),
+    Spec = esockd:udp_child_spec(echo, 5000, [], MFA),
     #{id := {listener_sup,{echo,5000}},
       modules := [esockd_udp],
       restart := transient,
@@ -92,8 +97,9 @@ t_open_dtls(Config) ->
                 {keyfile,  esockd_ct:keyfile(Config)},
                 {verify, verify_none}
                ],
-    {ok, _} = esockd:open_dtls(echo, 5000, [{dtls_options, DtlsOpts}],
-                               {dtls_echo_server, start_link, []}),
+    {ok, _} = esockd:open_dtls(echo, 5000,
+                               [{dtls_options, DtlsOpts},
+                                {connection_mfargs, dtls_echo_server}]),
     {ok, Sock} = ssl:connect({127,0,0,1}, 5000, [binary,
                                                  {protocol, dtls},
                                                  {active, false},
@@ -105,7 +111,9 @@ t_open_dtls(Config) ->
     ok = esockd:close(echo, 5000).
 
 t_dtls_child_spec(_) ->
-    Spec = esockd:dtls_child_spec(echo, 8883, [], {udp_echo_server, start_link, []}),
+    MFA = {udp_echo_server, start_link, []},
+    Spec = esockd:dtls_child_spec(echo, 8883, [{connection_mfargs, MFA}]),
+    Spec = esockd:dtls_child_spec(echo, 8883, [], MFA),
      #{id := {listener_sup,{echo,8883}},
        modules := [esockd_listener_sup],
        restart := transient,
@@ -114,7 +122,9 @@ t_dtls_child_spec(_) ->
       } = Spec.
 
 t_child_spec(_) ->
-    Spec = esockd:child_spec(echo, 5000, [], {echo_server, start_link, []}),
+    MFA = {udp_echo_server, start_link, []},
+    Spec = esockd:child_spec(echo, 5000, [{connection_mfargs, MFA}]),
+    Spec = esockd:child_spec(echo, 5000, [], MFA),
     #{id := {listener_sup, {echo,5000}},
       modules := [esockd_listener_sup],
       restart := transient,
@@ -123,7 +133,7 @@ t_child_spec(_) ->
      } = Spec.
 
 t_listeners(_) ->
-    {ok, LSup} = esockd:open(echo, 6000, [], {echo_server, start_link, []}),
+    {ok, LSup} = esockd:open(echo, 6000, [{connection_mfargs, echo_server}]),
     [{{echo, 6000}, LSup}] = esockd:listeners(),
     ?assertEqual(LSup, esockd:listener({echo, 6000})),
     ok = esockd:close(echo, 6000),
@@ -131,7 +141,7 @@ t_listeners(_) ->
     ?assertException(error, not_found, esockd:listener({echo, 6000})).
 
 t_get_stats(_) ->
-    {ok, _LSup} = esockd:open(echo, 6000, [], {echo_server, start_link, []}),
+    {ok, _LSup} = esockd:open(echo, 6000, [{connection_mfargs, echo_server}]),
     {ok, Sock1} = gen_tcp:connect("127.0.0.1", 6000, [{active, false}]),
     {ok, Sock2} = gen_tcp:connect("127.0.0.1", 6000, [{active, false}]),
     timer:sleep(10),
@@ -143,44 +153,50 @@ t_get_stats(_) ->
     ok = esockd:close(echo, 6000).
 
 t_get_options(_) ->
-    {ok, _LSup} = esockd:open(echo, 6000, [{acceptors, 4}],
-                              {echo_server, start_link, []}),
-    [{acceptors, 4}] = esockd:get_options({echo, 6000}),
+    {ok, _LSup} = esockd:open(echo, 6000,
+                              [{acceptors, 4},
+                               {connection_mfargs, {echo_server, start_link}}]),
+    [{acceptors, 4},
+     {connection_mfargs, {echo_server, start_link}}] = esockd:get_options({echo, 6000}),
     ok = esockd:close(echo, 6000),
     ?assertException(error, not_found, esockd:get_options({echo, 6000})),
 
-    {ok, _LSup1} = esockd:open_dtls(dtls_echo, 6000, [{acceptors, 4}],
-                               {dtls_echo_server, start_link, []}),
-    [{acceptors, 4}] = esockd:get_options({dtls_echo, 6000}),
+    {ok, _LSup1} = esockd:open_dtls(dtls_echo, 6000,
+                                    [{acceptors, 4},
+                                     {connection_mfargs, {dtls_echo_server, start_link}}]),
+    [{acceptors, 4},
+     {connection_mfargs, {dtls_echo_server, start_link}}] = esockd:get_options({dtls_echo, 6000}),
     ok = esockd:close(dtls_echo, 6000),
     ?assertException(error, not_found, esockd:get_options({dtls_echo, 6000})),
 
-    {ok, _LSup2} = esockd:open_udp(udp_echo, 6000, [{acceptors, 4}],
-                               {udp_echo_server, start_link, []}),
-    [{acceptors, 4}] = esockd:get_options({udp_echo, 6000}),
+    {ok, _LSup2} = esockd:open_udp(udp_echo, 6000,
+                                   [{acceptors, 4},
+                                    {connection_mfargs, {udp_echo_server, start_link, []}}]),
+    [{acceptors, 4},
+     {connection_mfargs, {udp_echo_server, start_link, []}}] = esockd:get_options({udp_echo, 6000}),
     ok = esockd:close(udp_echo, 6000),
     ?assertException(error, not_found, esockd:get_options({udp_echo, 6000})).
 
 t_get_acceptors(_) ->
-    {ok, _LSup} = esockd:open(echo, 6000, [{acceptors, 4}],
-                              {echo_server, start_link, []}),
+    {ok, _LSup} = esockd:open(echo, 6000,
+                              [{acceptors, 4}, {connection_mfargs, echo_server}]),
     ?assertEqual(4, esockd:get_acceptors({echo, 6000})),
     ok = esockd:close(echo, 6000),
 
-    {ok, _LSup1} = esockd:open_dtls(dtls_echo, 6000, [{acceptors, 4}],
-                               {dtls_echo_server, start_link, []}),
+    {ok, _LSup1} = esockd:open_dtls(dtls_echo, 6000,
+                                    [{acceptors, 4}, {connection_mfargs, dtls_echo_server}]),
     ?assertEqual(4, esockd:get_acceptors({dtls_echo, 6000})),
     ok = esockd:close(dtls_echo, 6000),
 
-    {ok, _LSup2} = esockd:open_udp(udp_echo, 6000, [{acceptors, 4}],
-                               {udp_echo_server, start_link, []}),
+    {ok, _LSup2} = esockd:open_udp(udp_echo, 6000,
+                                   [{acceptors, 4}, {connection_mfargs, udp_echo_server}]),
     %% fixed 1
     ?assertEqual(1, esockd:get_acceptors({udp_echo, 6000})),
     ok = esockd:close(udp_echo, 6000).
 
 t_get_set_max_connections(_) ->
-    {ok, _LSup} = esockd:open(echo, 7000, [{max_connections, 4}],
-                              {echo_server, start_link, []}),
+    {ok, _LSup} = esockd:open(echo, 7000,
+                              [{max_connections, 4}, {connection_mfargs, echo_server}]),
     ?assertEqual(4, esockd:get_max_connections({echo, 7000})),
     {ok, _Sock1} = gen_tcp:connect("localhost", 7000, [{active, false}]),
     {ok, _Sock2} = gen_tcp:connect("localhost", 7000, [{active, false}]),
@@ -190,15 +206,17 @@ t_get_set_max_connections(_) ->
     ?assertEqual({error, closed}, gen_tcp:recv(Sock3, 0)),
     ok = esockd:close(echo, 7000),
 
-    {ok, _LSup1} = esockd:open_dtls(dtls_echo, 7000, [{max_connections, 4}],
-                               {dtls_echo_server, start_link, []}),
+    {ok, _LSup1} = esockd:open_dtls(dtls_echo, 7000,
+                                    [{max_connections, 4},
+                                     {connection_mfargs, dtls_echo_server}]),
     ?assertEqual(4, esockd:get_max_connections({dtls_echo, 7000})),
     esockd:set_max_connections({dtls_echo, 7000}, 16),
     ?assertEqual(16, esockd:get_max_connections({dtls_echo, 7000})),
     ok = esockd:close(dtls_echo, 7000),
 
-    {ok, _LSup2} = esockd:open_udp(udp_echo, 7000, [{max_connections, 4}],
-                               {udp_echo_server, start_link, []}),
+    {ok, _LSup2} = esockd:open_udp(udp_echo, 7000,
+                                   [{max_connections, 4},
+                                    {connection_mfargs, udp_echo_server}]),
     ?assertEqual(4, esockd:get_max_connections({udp_echo, 7000})),
     esockd:set_max_connections({udp_echo, 7000}, 16),
     ?assertEqual(16, esockd:get_max_connections({udp_echo, 7000})),
@@ -206,8 +224,8 @@ t_get_set_max_connections(_) ->
 
 t_get_set_max_conn_rate(_) ->
     LimiterOpt = #{module => esockd_limiter, capacity => 100, interval => 1},
-    {ok, _LSup} = esockd:open(echo, 7000, [{limiter, LimiterOpt}],
-                              {echo_server, start_link, []}),
+    {ok, _LSup} = esockd:open(echo, 7000, 
+                              [{limiter, LimiterOpt}, {connection_mfargs, echo_server}]),
     ?assertEqual({100, 1}, esockd:get_max_conn_rate({echo, 7000})),
     esockd:set_max_conn_rate({echo, 7000}, LimiterOpt#{capacity := 50, interval := 2}),
     ?assertEqual({50, 2}, esockd:get_max_conn_rate({echo, 7000})),
@@ -215,16 +233,18 @@ t_get_set_max_conn_rate(_) ->
     ?assertException(error, not_found, esockd:get_max_conn_rate({echo, 7000})),
 
 
-    {ok, _LSup1} = esockd:open_dtls(dtls_echo, 7000, [{limiter, LimiterOpt}],
-                                    {dtls_echo_server, start_link, []}),
+    {ok, _LSup1} = esockd:open_dtls(dtls_echo, 7000,
+                                    [{limiter, LimiterOpt},
+                                     {connection_mfargs, dtls_echo_server}]),
     ?assertEqual({100, 1}, esockd:get_max_conn_rate({dtls_echo, 7000})),
     esockd:set_max_conn_rate({dtls_echo, 7000}, LimiterOpt#{capacity := 50, interval := 2}),
     ?assertEqual({50, 2}, esockd:get_max_conn_rate({dtls_echo, 7000})),
     ok = esockd:close(dtls_echo, 7000),
     ?assertException(error, not_found, esockd:get_max_conn_rate({dtls_echo, 7000})),
 
-    {ok, _LSup2} = esockd:open_udp(udp_echo, 7000, [{limiter, LimiterOpt}],
-                                   {udp_echo_server, start_link, []}),
+    {ok, _LSup2} = esockd:open_udp(udp_echo, 7000,
+                                   [{limiter, LimiterOpt},
+                                    {connection_mfargs, udp_echo_server}]),
     ?assertEqual({100, 1}, esockd:get_max_conn_rate({udp_echo, 7000})),
     esockd:set_max_conn_rate({udp_echo, 7000}, LimiterOpt#{capacity := 50, interval := 2}),
     ?assertEqual({50, 2}, esockd:get_max_conn_rate({udp_echo, 7000})),
@@ -232,7 +252,7 @@ t_get_set_max_conn_rate(_) ->
     ?assertException(error, not_found, esockd:get_max_conn_rate({udp_echo, 7000})).
 
 t_get_current_connections(Config) ->
-    {ok, _LSup} = esockd:open(echo, 7000, [], {echo_server, start_link, []}),
+    {ok, _LSup} = esockd:open(echo, 7000, [{connection_mfargs, {echo_server, start_link, []}}]),
     {ok, Sock1} = gen_tcp:connect("127.0.0.1", 7000, [{active, false}]),
     {ok, Sock2} = gen_tcp:connect("127.0.0.1", 7000, [{active, false}]),
     timer:sleep(10),
@@ -250,8 +270,8 @@ t_get_current_connections(Config) ->
                ],
     ClientOpts = [binary, {protocol, dtls}, {verify, verify_none}],
     {ok, _LSup1} = esockd:open_dtls(dtls_echo, 7000,
-                                    [{dtls_options, DtlsOpts}, {udp_options, UdpOpts}],
-                                    {dtls_echo_server, start_link, []}),
+                                    [{dtls_options, DtlsOpts}, {udp_options, UdpOpts},
+                                     {connection_mfargs, dtls_echo_server}]),
     {ok, DtlsSock1} = ssl:connect({127,0,0,1}, 7000, ClientOpts, 5000),
     {ok, DtlsSock2} = ssl:connect({127,0,0,1}, 7000, ClientOpts, 5000),
     timer:sleep(10),
@@ -260,7 +280,7 @@ t_get_current_connections(Config) ->
     ok = ssl:close(DtlsSock2),
     ok = esockd:close(dtls_echo, 7000),
 
-    {ok, _LSup2} = esockd:open_udp(udp_echo, 7001, [], {udp_echo_server, start_link, []}),
+    {ok, _LSup2} = esockd:open_udp(udp_echo, 7001, [{connection_mfargs, udp_echo_server}]),
     {ok, UdpSock1} = gen_udp:open(0, [binary, {active, false}]),
     {ok, UdpSock2} = gen_udp:open(0, [binary, {active, false}]),
     gen_udp:send(UdpSock1, {127,0,0,1}, 7001, <<"test">>),
@@ -272,7 +292,7 @@ t_get_current_connections(Config) ->
     ok = esockd:close(udp_echo, 7001).
 
 t_get_shutdown_count(Config) ->
-    {ok, _LSup} = esockd:open(echo, 7000, [], {echo_server, start_link, []}),
+    {ok, _LSup} = esockd:open(echo, 7000, [{connection_mfargs, echo_server}]),
     {ok, Sock1} = gen_tcp:connect("127.0.0.1", 7000, [{active, false}]),
     {ok, Sock2} = gen_tcp:connect("127.0.0.1", 7000, [{active, false}]),
     ok = gen_tcp:close(Sock1),
@@ -288,8 +308,8 @@ t_get_shutdown_count(Config) ->
                ],
     ClientOpts = [binary, {protocol, dtls}, {verify, verify_none}],
     {ok, _LSup1} = esockd:open_dtls(dtls_echo, 7000,
-                                    [{dtls_options, DtlsOpts}, {udp_options, UdpOpts}],
-                                    {dtls_echo_server, start_link, []}),
+                                    [{dtls_options, DtlsOpts}, {udp_options, UdpOpts},
+                                     {connection_mfargs, dtls_echo_server}]),
     {ok, DtlsSock1} = ssl:connect({127,0,0,1}, 7000, ClientOpts, 5000),
     {ok, DtlsSock2} = ssl:connect({127,0,0,1}, 7000, ClientOpts, 5000),
     ok = ssl:close(DtlsSock1),
@@ -298,7 +318,7 @@ t_get_shutdown_count(Config) ->
     ?assertEqual([], esockd:get_shutdown_count({dtls_echo, 7000})),
     ok = esockd:close(dtls_echo, 7000),
 
-    {ok, _LSup2} = esockd:open_udp(udp_echo, 7001, [], {udp_echo_server, start_link, []}),
+    {ok, _LSup2} = esockd:open_udp(udp_echo, 7001, [{connection_mfargs, udp_echo_server}]),
     {ok, UdpSock1} = gen_udp:open(0, [binary, {active, false}]),
     {ok, UdpSock2} = gen_udp:open(0, [binary, {active, false}]),
     gen_udp:send(UdpSock1, {127,0,0,1}, 7001, <<"test">>),
@@ -312,8 +332,8 @@ t_get_shutdown_count(Config) ->
 t_update_options(_) ->
     {ok, _LSup} = esockd:open(echo, 6000,
                               [{acceptors, 4},
-                               {tcp_options, [{backlog, 128}]}],
-                              {echo_server, start_link, []}),
+                               {tcp_options, [{backlog, 128}]},
+                               {connection_mfargs, echo_server}]),
     ?assertEqual(4, esockd:get_acceptors({echo, 6000})),
     {ok, Sock1} = gen_tcp:connect("127.0.0.1", 6000, [binary, {active, false}]),
     %% Backlog size can not be changed
@@ -331,7 +351,8 @@ t_update_options(_) ->
         esockd:set_options({echo, 6000},
                            [{acceptors, 16},
                             tune_buffer,
-                            {tcp_options, [{send_timeout_close, false}]}])
+                            {tcp_options, [{send_timeout_close, false}]},
+                            {connection_mfargs, {const_server, start_link, [<<"HEY">>]}}])
     ),
     {ok, Sock2} = gen_tcp:connect("127.0.0.1", 6000, [binary, {active, false}]),
     ?assertEqual(16, esockd:get_acceptors({echo, 6000})),
@@ -339,12 +360,12 @@ t_update_options(_) ->
     ok = gen_tcp:send(Sock1, <<"Sock1">>),
     {ok, <<"Sock1">>} = gen_tcp:recv(Sock1, 0),
     ok = gen_tcp:send(Sock2, <<"Sock2">>),
-    {ok, <<"Sock2">>} = gen_tcp:recv(Sock2, 0),
+    {ok, <<"HEY">>} = gen_tcp:recv(Sock2, 0),
     ok = esockd:close(echo, 6000).
 
 t_update_options_error(_) ->
-    {ok, _LSup} = esockd:open(echo, 6000, [{acceptors, 4}],
-                              {echo_server, start_link, []}),
+    {ok, _LSup} = esockd:open(echo, 6000,
+                              [{acceptors, 4}, {connection_mfargs, echo_server}]),
     ?assertEqual(4, esockd:get_acceptors({echo, 6000})),
     {ok, Sock1} = gen_tcp:connect("127.0.0.1", 6000, [binary, {active, false}]),
     ?assertEqual( {error, bad_access_rules}
@@ -379,8 +400,8 @@ t_update_tls_options(Config) ->
                     , {cacertfile, esockd_ct:cacertfile(Config)}
                     , {customize_hostname_check, [{match_fun, fun(_, _) -> true end}]}
                     ],
-    {ok, _LSup} = esockd:open(echo_tls, LPort, [{ssl_options, SslOpts1}],
-                              {echo_server, start_link, []}),
+    {ok, _LSup} = esockd:open(echo_tls, LPort,
+                              [{ssl_options, SslOpts1}, {connection_mfargs, echo_server}]),
     {ok, Sock1} = ssl:connect("localhost", LPort, ClientSslOpts, 1000),
 
     ok = esockd:set_options({echo_tls, LPort}, [{ssl_options, [{verify, verify_peer}]}]),
@@ -405,8 +426,7 @@ t_update_tls_options(Config) ->
 
 t_allow_deny(_) ->
     AccessRules = [{allow, "192.168.1.0/24"}],
-    {ok, _LSup} = esockd:open(echo, 7000, [{access_rules, AccessRules}],
-                              {echo_server, start_link, []}),
+    {ok, _LSup} = esockd:open(echo, 7000, [{access_rules, AccessRules}]),
     ?assertEqual([{allow, "192.168.1.0/24"}], esockd:get_access_rules({echo, 7000})),
     ok = esockd:allow({echo, 7000}, "10.10.0.0/16"),
     ?assertEqual([{allow, "10.10.0.0/16"},
@@ -421,8 +441,7 @@ t_allow_deny(_) ->
 
     %% dtls
 
-    {ok, _LSup1} = esockd:open_dtls(dtls_echo, 7000, [{access_rules, AccessRules}],
-                                    {dtls_echo_server, start_link, []}),
+    {ok, _LSup1} = esockd:open_dtls(dtls_echo, 7000, [{access_rules, AccessRules}]),
     ?assertEqual([{allow, "192.168.1.0/24"}], esockd:get_access_rules({dtls_echo, 7000})),
     ok = esockd:allow({dtls_echo, 7000}, "10.10.0.0/16"),
     ?assertEqual([{allow, "10.10.0.0/16"},
@@ -437,8 +456,7 @@ t_allow_deny(_) ->
 
     %% udp
 
-    {ok, _LSup2} = esockd:open_dtls(udp_echo, 7001, [{access_rules, AccessRules}],
-                                    {udp_echo_server, start_link, []}),
+    {ok, _LSup2} = esockd:open_dtls(udp_echo, 7001, [{access_rules, AccessRules}]),
     ?assertEqual([{allow, "192.168.1.0/24"}], esockd:get_access_rules({udp_echo, 7001})),
     ok = esockd:allow({udp_echo, 7001}, "10.10.0.0/16"),
     ?assertEqual([{allow, "10.10.0.0/16"},
@@ -499,8 +517,9 @@ t_tune_fun_overload(_) ->
     Ret = {error, overloaded},
     LPort = 7003,
     Name = tune_echo_overload,
-    {ok, _LSup} = esockd:open(Name, LPort, [{tune_fun, {?MODULE, sock_tune_fun, [Ret]}}],
-                              {echo_server, start_link, []}),
+    {ok, _LSup} = esockd:open(Name, LPort,
+                              [{tune_fun, {?MODULE, sock_tune_fun, [Ret]}},
+                               {connection_mfargs, {echo_server, start_link, []}}]),
     {ok, Socket} = gen_tcp:connect("127.0.0.1", LPort, [{active, true}]),
     receive
         {tcp_closed, S} ->
@@ -522,8 +541,8 @@ t_tune_fun_ok(_) ->
     LPort = 7004,
     Name = tune_echo_ok,
     {ok, _LSup} = esockd:open(Name, LPort,
-                              [{tune_fun, {?MODULE, sock_tune_fun, [Ret]}}],
-                              {echo_server, start_link, []}),
+                              [{tune_fun, {?MODULE, sock_tune_fun, [Ret]}},
+                               {connection_mfargs, echo_server}]),
     {ok, _S} = gen_tcp:connect("127.0.0.1", LPort, [{active, true}]),
     timer:sleep(10),
     Cnts = esockd_server:get_stats({Name, LPort}),
@@ -553,8 +572,7 @@ do_listener_handle_port_exit(Config, IsTls) ->
                    false -> []
                end,
     %% GIVEN: when listener is started
-    {ok, LSup} = esockd:open(Name, LPort, OpenOpts,
-                              {echo_server, start_link, []}),
+    {ok, LSup} = esockd:open(Name, LPort, [{connection_mfargs, echo_server} | OpenOpts]),
     {LMod, LPid} = esockd_listener_sup:listener(LSup),
     LState = LMod:get_state(LPid),
     PortInUse = proplists:get_value(listen_port, LState),

--- a/test/esockd_connection_sup_SUITE.erl
+++ b/test/esockd_connection_sup_SUITE.erl
@@ -114,7 +114,7 @@ t_handle_unexpected(_) ->
     {noreply, state} = esockd_connection_sup:handle_info(info, state).
 
 with_conn_sup(Opts, Fun) ->
-    {ok, ConnSup} = esockd_connection_sup:start_link(Opts, {echo_server, start_link, []}),
+    {ok, ConnSup} = esockd_connection_sup:start_link([{connection_mfargs, echo_server} | Opts]),
     Fun(ConnSup),
     ok = esockd_connection_sup:stop(ConnSup).
 

--- a/test/esockd_udp_SUITE.erl
+++ b/test/esockd_udp_SUITE.erl
@@ -68,8 +68,11 @@ udp_send_and_recv(Sock, Port, Data) ->
     ok.
 
 with_udp_server(TestFun) ->
-    MFA = {?MODULE, udp_echo_init, []},
-    {ok, Srv} = esockd_udp:server(test, {{127,0,0,1}, 6000}, [], MFA),
+    dbg:tracer(),
+    dbg:p(all, c),
+    dbg:tpl({emqx_connection_sup, '_', '_'}, x),
+    MFA = {?MODULE, udp_echo_init},
+    {ok, Srv} = esockd_udp:server(test, {{127,0,0,1}, 6000}, [{connection_mfargs, MFA}]),
     TestFun(Srv, 6000),
     ok = esockd_udp:stop(Srv).
 


### PR DESCRIPTION
Some listening socket options can not be changed after the socket has been bound (e.g. `backlog`). Before this PR, an attempt to change them is made (i.e. during the call `esockd:set_options/2`) if they were set once during listener setup but haven't changed since then.

Also, pull socket-related options for DTLS listener from `udp_options` property. This ensures that they are not getting into `ssl:handshake/3` later on as before, when they had to be part of `dtls_options` property.

Also, turn `MFA` from argument into an option, and accommodate APIs for that. Make it possible to change it at runtime with the help of `esockd:setopts/2`.

Part of [EMQX-11527](https://emqx.atlassian.net/browse/EMQX-11527).
Part of [EMQX-11528](https://emqx.atlassian.net/browse/EMQX-11528).
