### PR TITLE
fix: fast fail on invalid ssl options

### DIFF
--- a/src/esockd.app.src
+++ b/src/esockd.app.src
@@ -1,7 +1,7 @@
 {application, esockd,
  [{description, "General Non-blocking TCP/SSL and UDP/DTLS Server"},
   {id, "esockd"},
-  {vsn, "5.9.7"},
+  {vsn, git},
   {modules, []},
   {registered, []},
   {applications, [kernel, stdlib, sasl, ssl, public_key]},

--- a/src/esockd_acceptor_sup.erl
+++ b/src/esockd_acceptor_sup.erl
@@ -126,7 +126,11 @@ ssl_upgrade_fun(Type, Opts) ->
           end,
     case proplists:get_value(Key, Opts) of
         undefined -> [];
-        SslOpts -> [esockd_transport:ssl_upgrade_fun(SslOpts)]
+        SslOpts ->
+            %% validate ssl options and prevent the listener from starting if
+            %% validation failed
+            _ = ssl:handle_options(SslOpts, server, undefined),
+            [esockd_transport:ssl_upgrade_fun(SslOpts)]
     end.
 
 tune_socket(Sock, []) ->

--- a/test/esockd_SUITE.erl
+++ b/test/esockd_SUITE.erl
@@ -404,9 +404,10 @@ t_update_tls_options(Config) ->
                               [{ssl_options, SslOpts1}, {connection_mfargs, echo_server}]),
     {ok, Sock1} = ssl:connect("localhost", LPort, ClientSslOpts, 1000),
 
-    ok = esockd:set_options({echo_tls, LPort}, [{ssl_options, [{verify, verify_peer}]}]),
-    ?assertEqual( {error, closed}
-                , ssl:connect("localhost", LPort, ClientSslOpts, 1000)),
+    ?assertError(
+        {badmatch, _},
+        esockd:set_options({echo_tls, LPort}, [{ssl_options, [{verify, verify_peer}]}])
+    ),
 
     ok = esockd:set_options({echo_tls, LPort}, [{ssl_options, SslOpts2}]),
     {ok, Sock2} = ssl:connect("localhost", LPort, ClientSslOpts, 1000),


### PR DESCRIPTION
Porting https://github.com/emqx/esockd/pull/186 to emqx 5.x