### PR TITLE
Check max connections config against ulimit and processes limit

### DIFF
--- a/include/esockd.hrl
+++ b/include/esockd.hrl
@@ -71,4 +71,24 @@
 -type ssl_option() :: ssl:ssl_option().
 -endif. % OTP_RELEASE
 
+
+-define(ERROR_MAXLIMIT, maxlimit).
+
+-define(ARG_ACCEPTED, accepted).
+-define(ARG_CLOSED_SYS_LIMIT, closed_sys_limit).
+-define(ARG_CLOSED_MAX_LIMIT, closed_max_limit).
+-define(ARG_CLOSED_OVERLOADED, closed_overloaded).
+-define(ARG_CLOSED_RATE_LIMITED, closed_rate_limited).
+-define(ARG_CLOSED_OTHER_REASONS, closed_other_reasons).
+
+-define(ACCEPT_RESULT_GROUPS,
+        [
+            ?ARG_ACCEPTED,
+            ?ARG_CLOSED_SYS_LIMIT,
+            ?ARG_CLOSED_MAX_LIMIT,
+            ?ARG_CLOSED_OVERLOADED,
+            ?ARG_CLOSED_RATE_LIMITED,
+            ?ARG_CLOSED_OTHER_REASONS
+        ]).
+
 -endif. % ESOCKD_HRL

--- a/src/esockd.erl
+++ b/src/esockd.erl
@@ -415,13 +415,14 @@ ulimit() ->
 
 find_max_fd([]) ->
     %% Magic!
+    %% According to Erlang/OTP doc, erlang:system_info(check_io)):
     %% Returns a list containing miscellaneous information about the emulators
     %% internal I/O checking. Notice that the content of the returned list can
     %% vary between platforms and over time. It is only guaranteed that a list
     %% is returned.
     1023;
 find_max_fd([CheckIoResult | More]) ->
-    case lists:keyfind(max_fds, CheckIoResult) of
+    case lists:keyfind(max_fds, 1, CheckIoResult) of
         {max_fds, N} when is_integer(N) andalso N > 0 ->
             N;
         _ ->

--- a/src/esockd_acceptor.erl
+++ b/src/esockd_acceptor.erl
@@ -320,12 +320,13 @@ inc_stats(#state{proto = Proto, listen_on = ListenOn}, Tag) ->
     _ = esockd_server:inc_stats({Proto, ListenOn}, Counter, 1),
     ok.
 
-counter(accepted) -> accepted;
-counter(emfile) -> closed_sys_limit;
-counter(enfile) -> closed_sys_limit;
-counter(overloaded) -> closed_overloaded;
-counter(rate_limited) -> closed_rate_limited;
-counter(_) -> closed_other_reasons.
+counter(accepted) -> ?ARG_ACCEPTED;
+counter(emfile) -> ?ARG_CLOSED_SYS_LIMIT;
+counter(enfile) -> ?ARG_CLOSED_SYS_LIMIT;
+counter(?ERROR_MAXLIMIT) -> ?ARG_CLOSED_MAX_LIMIT;
+counter(overloaded) -> ?ARG_CLOSED_OVERLOADED;
+counter(rate_limited) -> ?ARG_CLOSED_RATE_LIMITED;
+counter(_) -> ?ARG_CLOSED_OTHER_REASONS.
 
 start_connection(ConnSup, Sock, UpgradeFuns) when is_pid(ConnSup) ->
     esockd_connection_sup:start_connection(ConnSup, Sock, UpgradeFuns);

--- a/src/esockd_connection_sup.erl
+++ b/src/esockd_connection_sup.erl
@@ -47,6 +47,8 @@
         , code_change/3
         ]).
 
+-include("esockd.hrl").
+
 -type(shutdown() :: brutal_kill | infinity | pos_integer()).
 
 -type option() :: {shutdown, shutdown()}
@@ -162,7 +164,7 @@ init(Opts) ->
 handle_call({start_connection, _Sock}, _From,
             State = #state{curr_connections = Conns, max_connections = MaxConns})
     when map_size(Conns) >= MaxConns ->
-    {reply, {error, maxlimit}, State};
+    {reply, {error, ?ERROR_MAXLIMIT}, State};
 
 handle_call({start_connection, Sock}, _From,
             State = #state{curr_connections = Conns, access_rules = Rules, mfargs = MFA}) ->

--- a/src/esockd_server.erl
+++ b/src/esockd_server.erl
@@ -46,6 +46,8 @@
         , code_change/3
         ]).
 
+-include("esockd.hrl").
+
 -record(state, {
     listener_props :: #{esockd:listener_ref() => #{_Name => _Value}}
 }).
@@ -97,12 +99,7 @@ del_stats({Protocol, ListenOn}) ->
 
 -spec ensure_stats({atom(), esockd:listen_on()}) -> ok.
 ensure_stats(StatsKey) ->
-    Stats = [accepted,
-             closed_sys_limit,
-             closed_overloaded,
-             closed_rate_limited,
-             closed_other_reasons],
-    ok = ?MODULE:init_stats(StatsKey, Stats),
+    ok = ?MODULE:init_stats(StatsKey, ?ACCEPT_RESULT_GROUPS),
     ok.
 
 -spec get_listener_prop(esockd:listener_ref(), _Name) -> _Value | undefined.


### PR DESCRIPTION
- Add a validation for `max_connections` config, make sure it's not greater than `ulimit` and `process_llimit`
- Added a new close reason counter group named `closed_max_limit`.