### PR TITLE
refactor: improve ssl options validation

### DIFF
--- a/src/esockd_listener_sup.erl
+++ b/src/esockd_listener_sup.erl
@@ -97,6 +97,14 @@ get_options(ListenerRef, _Sup) ->
     esockd_server:get_listener_prop(ListenerRef, options).
 
 set_options(ListenerRef, Sup, Opts) ->
+    case esockd_acceptor_sup:check_options(Opts) of
+        ok ->
+            do_set_options(ListenerRef, Sup, Opts);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+do_set_options(ListenerRef, Sup, Opts) ->
     OptsWas = esockd_server:get_listener_prop(ListenerRef, options),
     OptsWas = esockd_server:set_listener_prop(ListenerRef, options,
                                               esockd:merge_opts(OptsWas, Opts)),


### PR DESCRIPTION
improves https://github.com/emqx/esockd/pull/191

Previously:
1. if the initial config is invalid, the error message is extremely hard to comprehend because it's a `throw` without context originated from `ssl` lib.
2. if trying to set invalid options, the it's a `badmatch` crash for the caller of `set_options` 

Now:
1. Initial invalid config results with an error with more context `invalid_ssl_option`
2. Invalid options set from `set_options` returns an `{error, Reason}` tuple (with the same context)

see test cases for more details
