### PR TITLE
feat: introduce `reset_options/2` facility

### DIFF
--- a/src/esockd.erl
+++ b/src/esockd.erl
@@ -53,6 +53,7 @@
 -export([ get_stats/1
         , get_options/1
         , set_options/2
+        , reset_options/2
         , get_acceptors/1
         ]).
 
@@ -274,8 +275,17 @@ get_options({Proto, ListenOn}) when is_atom(Proto) ->
 %% because they require a listener restart, function returns an error.
 -spec set_options({atom(), listen_on()}, options()) ->
     ok | {error, not_supported | _UpdateErrorReason}.
-set_options({Proto, ListenOn}, Options) when is_atom(Proto) ->
-    with_listener_ref({Proto, ListenOn}, ?FUNCTION_NAME, [Options]).
+set_options({Proto, _ListenOn} = ListenerRef, Options) when is_atom(Proto) ->
+    OptionsWas = get_options(ListenerRef),
+    OptionsMerged = merge_opts(OptionsWas, Options),
+    with_listener_ref(ListenerRef, ?FUNCTION_NAME, [OptionsMerged]).
+
+%% @doc Replace set of applicable options
+%% See `set_options/2`.
+-spec reset_options({atom(), listen_on()}, options()) ->
+    ok | {error, not_supported | _UpdateErrorReason}.
+reset_options({Proto, _ListenOn} = ListenerRef, Options) when is_atom(Proto) ->
+    with_listener_ref(ListenerRef, set_options, [Options]).
 
 %% @doc Get acceptors number
 -spec(get_acceptors({atom(), listen_on()}) -> pos_integer()).

--- a/src/esockd.erl
+++ b/src/esockd.erl
@@ -270,7 +270,7 @@ get_stats({Proto, ListenOn}) when is_atom(Proto) ->
 get_options({Proto, ListenOn}) when is_atom(Proto) ->
     with_listener_ref({Proto, ListenOn}, ?FUNCTION_NAME, []).
 
-%% @doc Set applicable options
+%% @doc Set applicable listener options, without affecting existing connections.
 %% If some options could not be set, either because they are not applicable or
 %% because they require a listener restart, function returns an error.
 -spec set_options({atom(), listen_on()}, options()) ->
@@ -280,8 +280,10 @@ set_options({Proto, _ListenOn} = ListenerRef, Options) when is_atom(Proto) ->
     OptionsMerged = merge_opts(OptionsWas, Options),
     with_listener_ref(ListenerRef, ?FUNCTION_NAME, [OptionsMerged]).
 
-%% @doc Replace set of applicable options
-%% See `set_options/2`.
+%% @doc Replace set of applicable listener options, without affecting existing
+%% connections. In contrast to `set_options/2` existing options are not preserved,
+%% and will be reset back to defaults if not present in `Options`.
+%% See also: `set_options/2`.
 -spec reset_options({atom(), listen_on()}, options()) ->
     ok | {error, not_supported | _UpdateErrorReason}.
 reset_options({Proto, _ListenOn} = ListenerRef, Options) when is_atom(Proto) ->

--- a/src/esockd_connection_sup.erl
+++ b/src/esockd_connection_sup.erl
@@ -63,7 +63,6 @@
           mfargs :: esockd:mfargs()
          }).
 
--define(TRANSPORT, esockd_transport).
 -define(ERROR_MSG(Format, Args),
         error_logger:error_msg("[~s] " ++ Format, [?MODULE | Args])).
 
@@ -105,8 +104,8 @@ start_connection(Sup, Sock, UpgradeFuns) ->
     case call(Sup, {start_connection, Sock}) of
         {ok, ConnPid} ->
             %% Transfer controlling from acceptor to connection
-            _ = ?TRANSPORT:controlling_process(Sock, ConnPid),
-            _ = ?TRANSPORT:ready(ConnPid, Sock, UpgradeFuns),
+            _ = esockd_transport:controlling_process(Sock, ConnPid),
+            _ = esockd_transport:ready(ConnPid, Sock, UpgradeFuns),
             {ok, ConnPid};
         ignore -> ignore;
         {error, Reason} ->
@@ -117,7 +116,7 @@ start_connection(Sup, Sock, UpgradeFuns) ->
 -spec start_connection_proc(esockd:mfargs(), esockd_transport:socket())
       -> {ok, pid()} | ignore | {error, term()}.
 start_connection_proc(MFA, Sock) ->
-    esockd:start_mfargs(MFA, ?TRANSPORT, Sock).
+    esockd:start_mfargs(MFA, esockd_transport, Sock).
 
 -spec(count_connections(pid()) -> integer()).
 count_connections(Sup) ->

--- a/src/esockd_listener.erl
+++ b/src/esockd_listener.erl
@@ -145,8 +145,7 @@ handle_call({set_options, Opts}, _From, State = #state{lsock = LSock, sockopts =
     SockOptsChanged = esockd:changed_opts(SockOptsIn, SockOpts),
     case inet:setopts(LSock, SockOptsChanged) of
         ok ->
-            SockOptsMerged = esockd:merge_opts(SockOpts, SockOptsChanged),
-            {reply, ok, State#state{sockopts = SockOptsMerged}};
+            {reply, ok, State#state{sockopts = SockOptsIn}};
         Error = {error, _} ->
             {reply, Error, State}
     end;

--- a/src/esockd_listener_sup.erl
+++ b/src/esockd_listener_sup.erl
@@ -105,9 +105,7 @@ set_options(ListenerRef, Sup, Opts) ->
     end.
 
 do_set_options(ListenerRef, Sup, Opts) ->
-    OptsWas = esockd_server:get_listener_prop(ListenerRef, options),
-    OptsWas = esockd_server:set_listener_prop(ListenerRef, options,
-                                              esockd:merge_opts(OptsWas, Opts)),
+    OptsWas = esockd_server:set_listener_prop(ListenerRef, options, Opts),
     ConnSup = esockd_server:get_listener_prop(ListenerRef, connection_sup),
     {Listener, ListenerPid} = esockd_server:get_listener_prop(ListenerRef, listener),
     Result = try

--- a/src/esockd_listener_sup.erl
+++ b/src/esockd_listener_sup.erl
@@ -108,9 +108,10 @@ do_set_options(ListenerRef, Sup, Opts) ->
     OptsWas = esockd_server:set_listener_prop(ListenerRef, options, Opts),
     ConnSup = esockd_server:get_listener_prop(ListenerRef, connection_sup),
     {Listener, ListenerPid} = esockd_server:get_listener_prop(ListenerRef, listener),
-    Result = try
+    try
         ensure_ok(esockd_connection_sup:set_options(ConnSup, Opts)),
-        ensure_ok(Listener:set_options(ListenerPid, Opts))
+        ensure_ok(Listener:set_options(ListenerPid, Opts)),
+        restart_acceptor_sup(ListenerRef, Sup)
     catch
         throw:{?MODULE, Error} ->
             %% Restore previous options
@@ -118,9 +119,7 @@ do_set_options(ListenerRef, Sup, Opts) ->
             ok = esockd_connection_sup:set_options(ConnSup, OptsWas),
             %% Listener has failed to set options, no need to restore
             Error
-    end,
-    ok = restart_acceptor_sup(ListenerRef, Sup),
-    Result.
+    end.
 
 restart_acceptor_sup(ListenerRef, Sup) ->
     _ = supervisor:terminate_child(Sup, acceptor_sup),

--- a/test/esockd_SUITE.erl
+++ b/test/esockd_SUITE.erl
@@ -551,6 +551,8 @@ t_update_tls_options(Config) ->
 
     ok = esockd:close(echo_tls, LPort).
 
+%% Verify that updating / resetting dTLS-related listener options is correctly
+%% reported as unsupported (due to lack of consistent support in Erlang/OTP).
 t_update_dtls_options(Config) ->
     UdpOpts = [{read_packets, 16}],
     DtlsOpts = [{protocol, dtls},
@@ -586,6 +588,7 @@ t_update_dtls_options(Config) ->
 
     {ok, DtlsSock2} = ssl:connect({127,0,0,1}, 7000, ClientOpts, 1000),
 
+    %% Both new and existing connections should still work.
     ok = ssl:send(DtlsSock1, <<"DtlsSock1">>),
     ok = ssl:send(DtlsSock2, <<"DtlsSock2">>),
     {ok, <<"DtlsSock1">>} = ssl:recv(DtlsSock1, 0),

--- a/test/esockd_SUITE.erl
+++ b/test/esockd_SUITE.erl
@@ -530,7 +530,7 @@ t_update_tls_options(Config) ->
     %% Existing TLS options might be incompatible with changed version.
     ?assertMatch(
        {error, #{ error := invalid_ssl_option
-                , reason := {options, incompatible, _}
+                , reason := {options, _Incompatible, _}
                 }},
         esockd:set_options({echo_tls, LPort},
                            [{ssl_options, [{versions, ['tlsv1.3']}]}])


### PR DESCRIPTION
Meant to be used in situations when `set_options/2` is too dumb: e.g. changing TLS version that in turn renders existing TLS server options incompatible.

See individual commits for details.