### PR TITLE
fix(pp2): strict TLV parsing — reject malformed remainder instead of silent drop

### DIFF
--- a/src/esockd_proxy_protocol.erl
+++ b/src/esockd_proxy_protocol.erl
@@ -23,7 +23,7 @@
 
 -ifdef(TEST).
 -export([get_proxy_attrs/1]).
--export([parse_v1/2, parse_v2/4, parse_pp2_tlv/2, parse_pp2_ssl/1]).
+-export([parse_v1/2, parse_v2/4, parse_pp2_tlv/2, parse_pp2_tlv/3, parse_pp2_ssl/1]).
 -endif.
 
 %% Protocol Command
@@ -260,13 +260,44 @@ parse_pp2_additional(<<>>, ProxySock) ->
     {ok, ProxySock};
 parse_pp2_additional(Bytes, ProxySock) when is_binary(Bytes) ->
     IgnoreGuard = fun(?PP2_TYPE_NOOP) -> false; (_Type) -> true end,
-    AdditionalInfo = parse_pp2_tlv(fun pp2_additional_field/1, Bytes, IgnoreGuard),
-    {ok, ProxySock#proxy_socket{pp2_additional_info = AdditionalInfo}}.
+    try parse_pp2_tlv(fun pp2_additional_field/1, Bytes, IgnoreGuard) of
+        {ok, AdditionalInfo} ->
+            {ok, ProxySock#proxy_socket{pp2_additional_info = AdditionalInfo}};
+        {error, {malformed_tlv, Remaining}} ->
+            log_malformed_pp2_tlv(top_level, Remaining, byte_size(Bytes)),
+            {error, {malformed_pp2_tlv, Remaining}}
+    catch
+        throw:{malformed_pp2_ssl_tlv, Remaining} = Reason ->
+            log_malformed_pp2_tlv(ssl_subtlv, Remaining, byte_size(Bytes)),
+            {error, Reason}
+    end.
 
+%% @doc Strict PROXY-Protocol v2 TLV parser.
+%%
+%% Returns `{ok, [Tuple]}' on a cleanly consumed byte stream, or
+%% `{error, {malformed_tlv, RemainingBytes}}' if a TLV's declared length
+%% overruns the buffer. The previous binary-comprehension implementation
+%% silently terminated on overrun, hiding any trailing TLVs (well-formed
+%% or not) from the caller.
+%%
+%% `Guard' decides whether a TLV's value is emitted; in either case the
+%% parser advances past the TLV's bytes.
 parse_pp2_tlv(Fun, Bytes) ->
     parse_pp2_tlv(Fun, Bytes, fun(_Any) -> true end).
+
 parse_pp2_tlv(Fun, Bytes, Guard) ->
-    [Fun({Type, Val}) || <<Type:8, Len:16, Val:Len/binary>> <= Bytes, Guard(Type)].
+    parse_pp2_tlv(Fun, Bytes, Guard, []).
+
+parse_pp2_tlv(_Fun, <<>>, _Guard, Acc) ->
+    {ok, lists:reverse(Acc)};
+parse_pp2_tlv(Fun, <<Type:8, Len:16, Val:Len/binary, Rest/binary>>, Guard, Acc) ->
+    Acc1 = case Guard(Type) of
+               true  -> [Fun({Type, Val}) | Acc];
+               false -> Acc
+           end,
+    parse_pp2_tlv(Fun, Rest, Guard, Acc1);
+parse_pp2_tlv(_Fun, Bad, _Guard, _Acc) when is_binary(Bad) ->
+    {error, {malformed_tlv, byte_size(Bad)}}.
 
 pp2_additional_field({?PP2_TYPE_ALPN, PP2_ALPN}) ->
     {pp2_alpn, PP2_ALPN};
@@ -277,32 +308,51 @@ pp2_additional_field({?PP2_TYPE_CRC32C, PP2_CRC32C}) ->
 pp2_additional_field({?PP2_TYPE_NETNS, PP2_NETNS}) ->
     {pp2_netns, PP2_NETNS};
 pp2_additional_field({?PP2_TYPE_SSL, PP2_SSL}) ->
-    {pp2_ssl, parse_pp2_ssl(PP2_SSL)};
+    case parse_pp2_ssl(PP2_SSL) of
+        {ok, SSLInfo} ->
+            {pp2_ssl, SSLInfo};
+        {error, {malformed_tlv, Remaining}} ->
+            throw({malformed_pp2_ssl_tlv, Remaining})
+    end;
 pp2_additional_field({Field, Value}) ->
     {{pp2_raw, Field}, Value}.
 
 parse_pp2_ssl(<<_Unused:5, PP2_CLIENT_CERT_SESS:1, PP2_CLIENT_CERT_CONN:1, PP2_CLIENT_SSL:1,
                 PP2_SSL_VERIFY:32, SubFields/bitstring>>) ->
-    [
-     %% The PP2_CLIENT_SSL flag indicates that the client connected over SSL/TLS. When
-     %% this field is present, the US-ASCII string representation of the TLS version is
-     %% appended at the end of the field in the TLV format using the type PP2_SUBTYPE_SSL_VERSION.
-     {pp2_ssl_client, bool(PP2_CLIENT_SSL)},
+    case parse_pp2_tlv(fun pp2_additional_ssl_field/1, SubFields) of
+        {ok, SubList} ->
+            {ok,
+             [
+              %% The PP2_CLIENT_SSL flag indicates that the client connected over SSL/TLS.
+              %% When this field is present, the US-ASCII string representation of the TLS
+              %% version is appended at the end of the field in the TLV format using the
+              %% type PP2_SUBTYPE_SSL_VERSION.
+              {pp2_ssl_client, bool(PP2_CLIENT_SSL)},
 
-     %% PP2_CLIENT_CERT_CONN indicates that the client provided a certificate over the
-     %% current connection.
-     {pp2_ssl_client_cert_conn, bool(PP2_CLIENT_CERT_CONN)},
+              %% PP2_CLIENT_CERT_CONN indicates that the client provided a certificate over
+              %% the current connection.
+              {pp2_ssl_client_cert_conn, bool(PP2_CLIENT_CERT_CONN)},
 
-     %% PP2_CLIENT_CERT_SESS indicates that the client provided a
-     %% certificate at least once over the TLS session this connection belongs to.
-     {pp2_ssl_client_cert_sess, bool(PP2_CLIENT_CERT_SESS)},
+              %% PP2_CLIENT_CERT_SESS indicates that the client provided a certificate at
+              %% least once over the TLS session this connection belongs to.
+              {pp2_ssl_client_cert_sess, bool(PP2_CLIENT_CERT_SESS)},
 
-     %% The <verify> field will be zero if the client presented a certificate
-     %% and it was successfully verified, and non-zero otherwise.
-     {pp2_ssl_verify, ssl_certificate_verified(PP2_SSL_VERIFY)}
+              %% The <verify> field will be zero if the client presented a certificate
+              %% and it was successfully verified, and non-zero otherwise.
+              {pp2_ssl_verify, ssl_certificate_verified(PP2_SSL_VERIFY)}
 
-     | parse_pp2_tlv(fun pp2_additional_ssl_field/1, SubFields)
-    ].
+              | SubList
+             ]};
+        {error, _} = Error ->
+            Error
+    end.
+
+log_malformed_pp2_tlv(Where, Remaining, TotalBytes) ->
+    logger:log(warning,
+               #{msg => "malformed_pp2_tlv",
+                 where => Where,
+                 remaining_bytes => Remaining,
+                 total_bytes => TotalBytes}).
 
 pp2_additional_ssl_field({?PP2_SUBTYPE_SSL_VERSION, PP2_SSL_VERSION}) ->
     {pp2_ssl_version, PP2_SSL_VERSION};

--- a/test/esockd_proxy_protocol_SUITE.erl
+++ b/test/esockd_proxy_protocol_SUITE.erl
@@ -39,8 +39,14 @@ groups() ->
      {parser, [sequence], [t_parse_v1,
                            t_parse_v2,
                            t_parse_pp2_additional,
+                           t_parse_pp2_additional_malformed,
                            t_parse_pp2_ssl,
-                           t_parse_pp2_tlv]},
+                           t_parse_pp2_ssl_malformed,
+                           t_parse_pp2_tlv,
+                           t_parse_pp2_tlv_empty,
+                           t_parse_pp2_tlv_malformed,
+                           t_parse_pp2_tlv_guard_skip,
+                           t_parse_v2_malformed_tlv_rejected]},
      {integration, [sequence], [t_ppv1_tcp4_connect,
                                t_ppv1_tcp6_connect,
                                t_ppv2_connect,
@@ -202,16 +208,72 @@ t_parse_pp2_additional(_) ->
 
 t_parse_pp2_ssl(_) ->
     Bin = <<01,00,05,"29zka",02,00,06,"219a3k",16#30,00,07,"abc.com",16#20,00,05,03,00,00,00,01>>,
-    [{pp2_ssl_client, false},
-     {pp2_ssl_client_cert_conn, false},
-     {pp2_ssl_client_cert_sess, true},
-     {pp2_ssl_verify, success}|_]
+    {ok, [{pp2_ssl_client, false},
+          {pp2_ssl_client_cert_conn, false},
+          {pp2_ssl_client_cert_sess, true},
+          {pp2_ssl_verify, success}|_]}
     = esockd_proxy_protocol:parse_pp2_ssl(<<0:5, 1:1, 0:1, 0:1, 0:32, Bin/binary>>).
+
+t_parse_pp2_ssl_malformed(_) ->
+    %% First sub-TLV declares Len=20 but only 5 bytes follow.
+    Bad = <<16#21:8, 20:16, "TLSv1">>,
+    {error, {malformed_tlv, _}}
+        = esockd_proxy_protocol:parse_pp2_ssl(<<0:5, 1:1, 0:1, 1:1, 0:32, Bad/binary>>).
 
 t_parse_pp2_tlv(_) ->
     Bin = <<01,00,05,"29zka",02,00,06,"219a3k",16#30,00,07,"abc.com",16#20,00,05,03,00,00,00,01>>,
-    [{1, <<"29zka">>}, {2, <<"219a3k">>}, {16#30, <<"abc.com">>}, {16#20, <<3,0,0,0,1>>}]
-    = esockd_proxy_protocol:parse_pp2_tlv(fun(E) -> E end, Bin).
+    {ok, [{1, <<"29zka">>}, {2, <<"219a3k">>}, {16#30, <<"abc.com">>}, {16#20, <<3,0,0,0,1>>}]}
+        = esockd_proxy_protocol:parse_pp2_tlv(fun(E) -> E end, Bin).
+
+t_parse_pp2_tlv_empty(_) ->
+    {ok, []} = esockd_proxy_protocol:parse_pp2_tlv(fun(E) -> E end, <<>>).
+
+t_parse_pp2_tlv_malformed(_) ->
+    %% A well-formed ALPN TLV followed by a TLV whose declared length (16#FFFF)
+    %% massively overruns the buffer — the old parser would silently return only
+    %% [{1, <<"abc">>}], hiding the malformed remainder. The strict parser must
+    %% surface the error.
+    Good = <<01, 00, 03, "abc">>,
+    BadHeader = <<02, 16#FF, 16#FF, "short">>,
+    Bin = <<Good/binary, BadHeader/binary>>,
+    {error, {malformed_tlv, R}}
+        = esockd_proxy_protocol:parse_pp2_tlv(fun(E) -> E end, Bin),
+    ?assert(R > 0),
+    %% A trailing legit TLV after a malformed one must also surface the malformed
+    %% condition rather than be silently dropped.
+    TrailingLegit = <<03, 00, 03, "xyz">>,
+    Bin2 = <<Good/binary, BadHeader/binary, TrailingLegit/binary>>,
+    {error, {malformed_tlv, _}}
+        = esockd_proxy_protocol:parse_pp2_tlv(fun(E) -> E end, Bin2).
+
+t_parse_pp2_tlv_guard_skip(_) ->
+    %% Guard returning false must still advance past the TLV's bytes — the
+    %% guarded-out TLV does not appear in the output, but the following TLV
+    %% parses correctly.
+    Bin = <<16#04, 0, 4, 0, 0, 0, 0, 01, 00, 03, "abc">>,
+    Guard = fun(16#04) -> false; (_) -> true end,
+    {ok, [{1, <<"abc">>}]}
+        = esockd_proxy_protocol:parse_pp2_tlv(fun(E) -> E end, Bin, Guard).
+
+t_parse_pp2_additional_malformed(_) ->
+    %% Top-level TLV with declared Len overshooting the buffer must cause
+    %% parse_v2/4 to reject the frame.
+    Bad = <<01, 16#FF, 16#FF, "short">>,
+    Frame = <<104,199,189,98,106,185,34,253,6000:16,8883:16, Bad/binary>>,
+    {error, {malformed_pp2_tlv, _}}
+        = esockd_proxy_protocol:parse_v2(16#1, 16#1, Frame,
+                                         #proxy_socket{inet = inet4}).
+
+t_parse_v2_malformed_tlv_rejected(_) ->
+    %% Malformed inner SSL sub-TLV must also propagate as a frame-level error.
+    BadSsl = <<16#21:8, 20:16, "TLSv1">>,
+    SslVal = <<0:5, 1:1, 0:1, 1:1, 0:32, BadSsl/binary>>,
+    SslLen = byte_size(SslVal),
+    Tlv = <<16#20:8, SslLen:16, SslVal/binary>>,
+    Frame = <<104,199,189,98,106,185,34,253,6000:16,8883:16, Tlv/binary>>,
+    {error, {malformed_pp2_ssl_tlv, _}}
+        = esockd_proxy_protocol:parse_v2(16#1, 16#1, Frame,
+                                         #proxy_socket{inet = inet4}).
 
 %%--------------------------------------------------------------------
 %% Test cases for pp server


### PR DESCRIPTION
## Summary

`parse_pp2_tlv/3` used a binary list comprehension. When a TLV's declared `Len` overran the remaining buffer, the binary generator silently terminated and the caller received only the well-formed prefix — any malformed remainder and the trailing TLVs hiding behind it disappeared without error or log.

This PR makes the PROXY-Protocol v2 TLV parser strict:

- `parse_pp2_tlv/3` is rewritten as an explicit recursive parser that returns `{ok, [Tuple]}` on clean end-of-stream or `{error, {malformed_tlv, RemainingBytes}}` on overrun. Guard semantics are preserved — a guarded-out TLV (e.g. `PP2_TYPE_NOOP`) still advances the parser past its bytes but is not emitted in the result.
- `parse_pp2_ssl/1` now returns `{ok, List} | {error, _}` and propagates the strict result from its sub-TLV parse.
- `parse_pp2_additional/2` threads the new return through. On a malformed top-level or SSL sub-TLV stream, `parse_v2/4` returns `{error, {malformed_pp2_tlv, _}}` or `{error, {malformed_pp2_ssl_tlv, _}}` and logs a warning, so `recv/3` rejects the frame rather than returning a half-parsed `#proxy_socket{}`.

`parse_pp2_tlv/2,3` and `parse_pp2_ssl/1` are only exported under `-ifdef(TEST)`, so the return-shape change has no production callers outside this module. Downstream broker code (which only consumes `recv/3`'s `{ok, _} | {error, _}` contract) sees a new error tag on malformed frames and the same success shape on well-formed ones.

## Tests

Added cases under the `parser` group of `esockd_proxy_protocol_SUITE`:

- `t_parse_pp2_tlv_empty` — empty bytes → `{ok, []}`.
- `t_parse_pp2_tlv_malformed` — overrun TLV → `{error, {malformed_tlv, _}}`; a trailing legit TLV after a malformed one still surfaces the malformed condition.
- `t_parse_pp2_tlv_guard_skip` — a guarded-out TLV still advances the parser past its bytes.
- `t_parse_pp2_additional_malformed` — malformed top-level TLV → `parse_v2/4` returns `{error, {malformed_pp2_tlv, _}}`.
- `t_parse_pp2_ssl_malformed` / `t_parse_v2_malformed_tlv_rejected` — malformed SSL sub-TLV propagates up to a frame-level error.

Updated the two existing parser tests (`t_parse_pp2_tlv`, `t_parse_pp2_ssl`) to expect the tagged return shape.

## Test plan

- [x] `make compile` — clean
- [x] `make xref` — clean
- [x] `rebar3 as test ct --suite=test/esockd_proxy_protocol_SUITE` — all 31 tests pass
- [x] `make dialyzer` — clean