### PR TITLE
feat: extract certificate subject alternative names

### DIFF
--- a/src/esockd_peercert.erl
+++ b/src/esockd_peercert.erl
@@ -49,9 +49,4 @@ subject_alt_names(PP2Info) when is_list(PP2Info) ->
     empty_subject_alt_names().
 
 empty_subject_alt_names() ->
-    #{
-        dns => [],
-        ip => [],
-        email => [],
-        uri => []
-    }.
+    nosan.

--- a/src/esockd_peercert.erl
+++ b/src/esockd_peercert.erl
@@ -16,11 +16,12 @@
 
 -module(esockd_peercert).
 
--export([subject/1, common_name/1]).
+-export([subject/1, common_name/1, subject_alt_names/1]).
 
--export_type([peercert/0]).
+-export_type([peercert/0, subject_alt_names/0]).
 
 -type(peercert() :: binary() | proplists:proplist()).
+-type(subject_alt_names() :: esockd_ssl:subject_alt_names()).
 
 -spec(subject(nossl | undefined | peercert()) -> undefined | binary()).
 subject(nossl)     -> undefined;
@@ -39,3 +40,18 @@ common_name(Cert) when is_binary(Cert) ->
 common_name(PP2Info) when is_list(PP2Info) ->
     proplists:get_value(pp2_ssl_cn, PP2Info).
 
+-spec(subject_alt_names(nossl | undefined | peercert()) -> subject_alt_names()).
+subject_alt_names(nossl)     -> empty_subject_alt_names();
+subject_alt_names(undefined) -> empty_subject_alt_names();
+subject_alt_names(Cert) when is_binary(Cert) ->
+    esockd_ssl:peer_cert_subject_alt_names(Cert);
+subject_alt_names(PP2Info) when is_list(PP2Info) ->
+    empty_subject_alt_names().
+
+empty_subject_alt_names() ->
+    #{
+        dns => [],
+        ip => [],
+        email => [],
+        uri => []
+    }.

--- a/src/esockd_ssl.erl
+++ b/src/esockd_ssl.erl
@@ -32,11 +32,13 @@
         ]).
 
 -type(certificate() :: binary()).
--type(subject_alt_names() :: #{
-        dns := [binary()],
-        ip := [binary()],
-        email := [binary()],
-        uri := [binary()]
+-type(subject_alt_names() ::
+    nosan
+    | #{
+        dns => [binary()],
+        ip => [binary()],
+        email => [binary()],
+        uri => [binary()]
     }).
 -export_type([certificate/0, subject_alt_names/0]).
 
@@ -126,8 +128,21 @@ find_subject_alt_names([]) ->
     undefined.
 
 normalize_general_names(Names) ->
-    Acc = lists:foldl(fun add_general_name/2, empty_subject_alt_names(), Names),
-    maps:map(fun(_NameType, Values) -> lists:reverse(Values) end, Acc).
+    Acc = lists:foldl(fun add_general_name/2, subject_alt_names_acc(), Names),
+    Sparse = maps:fold(
+        fun
+            (_NameType, [], SparseAcc) ->
+                SparseAcc;
+            (NameType, Values, SparseAcc) ->
+                SparseAcc#{NameType => lists:reverse(Values)}
+        end,
+        #{},
+        Acc
+    ),
+    case map_size(Sparse) of
+        0 -> empty_subject_alt_names();
+        _ -> Sparse
+    end.
 
 add_general_name({dNSName, Name}, Acc) ->
     add_string_name(dns, Name, Acc);
@@ -206,6 +221,9 @@ is_byte(Byte) ->
     is_integer(Byte) andalso Byte >= 0 andalso Byte =< 255.
 
 empty_subject_alt_names() ->
+    nosan.
+
+subject_alt_names_acc() ->
     #{
         dns => [],
         ip => [],

--- a/src/esockd_ssl.erl
+++ b/src/esockd_ssl.erl
@@ -26,12 +26,19 @@
 -export([ peer_cert_issuer/1
         , peer_cert_subject/1
         , peer_cert_common_name/1
+        , peer_cert_subject_alt_names/1
         , peer_cert_subject_items/2
         , peer_cert_validity/1
         ]).
 
 -type(certificate() :: binary()).
--export_type([certificate/0]).
+-type(subject_alt_names() :: #{
+        dns := [binary()],
+        ip := [binary()],
+        email := [binary()],
+        uri := [binary()]
+    }).
+-export_type([certificate/0, subject_alt_names/0]).
 
 %% Return a string describing the certificate's issuer.
 -spec(peer_cert_issuer(certificate()) -> binary()).
@@ -57,6 +64,14 @@ peer_cert_common_name(Cert) ->
         undefined -> undefined;
         CNs       -> iolist_to_binary(string:join(CNs, ","))
      end.
+
+-spec(peer_cert_subject_alt_names(certificate()) -> subject_alt_names()).
+peer_cert_subject_alt_names(Cert) ->
+    cert_info(fun(#'OTPCertificate' {
+                     tbsCertificate = #'OTPTBSCertificate' {
+                       extensions = Extensions }}) ->
+                      subject_alt_names_from_extensions(Extensions)
+              end, Cert).
 
 %% Return the parts of the certificate's subject.
 -spec(peer_cert_subject_items(certificate(), tuple()) -> [string()] | undefined).
@@ -88,6 +103,115 @@ find_by_type(Type, {rdnSequence, RDNs}) ->
         [] -> undefined;
         L  -> [format_asn1_value(V) || V <- L]
     end.
+
+subject_alt_names_from_extensions(asn1_NOVALUE) ->
+    empty_subject_alt_names();
+subject_alt_names_from_extensions(Extensions) when is_list(Extensions) ->
+    case find_subject_alt_names(Extensions) of
+        Names when is_list(Names) ->
+            normalize_general_names(Names);
+        _ ->
+            empty_subject_alt_names()
+    end;
+subject_alt_names_from_extensions(_) ->
+    empty_subject_alt_names().
+
+find_subject_alt_names([
+    #'Extension'{extnID = ?'id-ce-subjectAltName', extnValue = Names} | _Rest
+]) ->
+    Names;
+find_subject_alt_names([_ | Rest]) ->
+    find_subject_alt_names(Rest);
+find_subject_alt_names([]) ->
+    undefined.
+
+normalize_general_names(Names) ->
+    Acc = lists:foldl(fun add_general_name/2, empty_subject_alt_names(), Names),
+    maps:map(fun(_NameType, Values) -> lists:reverse(Values) end, Acc).
+
+add_general_name({dNSName, Name}, Acc) ->
+    add_string_name(dns, Name, Acc);
+add_general_name({iPAddress, IPAddress}, Acc) ->
+    add_ip_name(IPAddress, Acc);
+add_general_name({rfc822Name, Email}, Acc) ->
+    add_string_name(email, Email, Acc);
+add_general_name({uniformResourceIdentifier, URI}, Acc) ->
+    add_string_name(uri, URI, Acc);
+add_general_name(_Other, Acc) ->
+    Acc.
+
+add_string_name(NameType, Value, Acc) ->
+    case to_binary(Value) of
+        {ok, Bin} ->
+            Acc#{NameType := [Bin | maps:get(NameType, Acc)]};
+        error ->
+            Acc
+    end.
+
+add_ip_name(IPAddress, Acc) ->
+    case ip_to_binary(IPAddress) of
+        {ok, Bin} ->
+            Acc#{ip := [Bin | maps:get(ip, Acc)]};
+        error ->
+            Acc
+    end.
+
+to_binary(Bin) when is_binary(Bin) ->
+    {ok, Bin};
+to_binary(String) when is_list(String) ->
+    case unicode:characters_to_binary(String) of
+        Bin when is_binary(Bin) ->
+            {ok, Bin};
+        _ ->
+            error
+    end;
+to_binary(_) ->
+    error.
+
+ip_to_binary(IPAddress) when is_tuple(IPAddress) ->
+    try iolist_to_binary(inet:ntoa(IPAddress)) of
+        Bin ->
+            {ok, Bin}
+    catch
+        _:_ ->
+            error
+    end;
+ip_to_binary(IPAddress) when is_binary(IPAddress) ->
+    ip_bytes_to_binary(binary_to_list(IPAddress));
+ip_to_binary(IPAddress) when is_list(IPAddress) ->
+    ip_bytes_to_binary(IPAddress);
+ip_to_binary(_) ->
+    error.
+
+ip_bytes_to_binary(Bytes) ->
+    case is_byte_list(Bytes) of
+        true ->
+            ip_byte_list_to_binary(Bytes);
+        false ->
+            error
+    end.
+
+ip_byte_list_to_binary([A, B, C, D]) ->
+    {ok, iolist_to_binary(inet:ntoa({A, B, C, D}))};
+ip_byte_list_to_binary(Bytes) when length(Bytes) =:= 16 ->
+    <<A:16, B:16, C:16, D:16, E:16, F:16, G:16, H:16>> = list_to_binary(Bytes),
+    {ok, iolist_to_binary(inet:ntoa({A, B, C, D, E, F, G, H}))};
+ip_byte_list_to_binary(_) ->
+    error.
+
+is_byte_list(Bytes) ->
+    lists:all(fun is_byte/1, Bytes).
+
+is_byte(Byte) ->
+    is_integer(Byte) andalso Byte >= 0 andalso Byte =< 255.
+
+empty_subject_alt_names() ->
+    #{
+        dns => [],
+        ip => [],
+        email => [],
+        uri => []
+    }.
 
 %%--------------------------------------------------------------------
 %% Formatting functions
@@ -261,4 +385,3 @@ flatten_ssl_list_item(N) when is_number (N) ->
 
 format(Fmt, Args) ->
     lists:flatten(io_lib:format(Fmt, Args)).
-

--- a/test/esockd_peercert_SUITE.erl
+++ b/test/esockd_peercert_SUITE.erl
@@ -38,18 +38,12 @@ t_common_name(Config) ->
     <<"C=CH">> = esockd_peercert:common_name([{pp2_ssl_cn, <<"C=CH">>}]).
 
 t_subject_alt_names(Config) ->
-    Empty = #{
-        dns => [],
-        ip => [],
-        email => [],
-        uri => []
-    },
-    Empty = esockd_peercert:subject_alt_names(nossl),
-    Empty = esockd_peercert:subject_alt_names(undefined),
-    Empty = esockd_peercert:subject_alt_names([{pp2_ssl_cn, <<"C=CH">>}]),
+    nosan = esockd_peercert:subject_alt_names(nossl),
+    nosan = esockd_peercert:subject_alt_names(undefined),
+    nosan = esockd_peercert:subject_alt_names([{pp2_ssl_cn, <<"C=CH">>}]),
     DerCert = pem_decode(esockd_ct:certfile(Config)),
-    ?assertMatch(
-        #{dns := [<<"Server">>, <<"dengzhongwendeMacBook-Pro.local">>, <<"localhost">>]},
+    ?assertEqual(
+        #{dns => [<<"Server">>, <<"dengzhongwendeMacBook-Pro.local">>, <<"localhost">>]},
         esockd_peercert:subject_alt_names(DerCert)
     ).
 

--- a/test/esockd_peercert_SUITE.erl
+++ b/test/esockd_peercert_SUITE.erl
@@ -37,8 +37,23 @@ t_common_name(Config) ->
     _CN = esockd_peercert:common_name(DerCert),
     <<"C=CH">> = esockd_peercert:common_name([{pp2_ssl_cn, <<"C=CH">>}]).
 
+t_subject_alt_names(Config) ->
+    Empty = #{
+        dns => [],
+        ip => [],
+        email => [],
+        uri => []
+    },
+    Empty = esockd_peercert:subject_alt_names(nossl),
+    Empty = esockd_peercert:subject_alt_names(undefined),
+    Empty = esockd_peercert:subject_alt_names([{pp2_ssl_cn, <<"C=CH">>}]),
+    DerCert = pem_decode(esockd_ct:certfile(Config)),
+    ?assertMatch(
+        #{dns := [<<"Server">>, <<"dengzhongwendeMacBook-Pro.local">>, <<"localhost">>]},
+        esockd_peercert:subject_alt_names(DerCert)
+    ).
+
 pem_decode(CertFile) ->
     {ok, CertBin} = file:read_file(CertFile),
     [{'Certificate', DerCert, _}] = public_key:pem_decode(CertBin),
     DerCert.
-

--- a/test/esockd_ssl_SUITE.erl
+++ b/test/esockd_ssl_SUITE.erl
@@ -64,7 +64,36 @@ t_peer_cert_subject_alt_names(_) ->
         esockd_ssl:peer_cert_subject_alt_names(san_cert())
     ).
 
+t_peer_cert_subject_alt_names_empty(_) ->
+    ?assertEqual(
+        #{
+            dns => [],
+            ip => [],
+            email => [],
+            uri => []
+        },
+        esockd_ssl:peer_cert_subject_alt_names(no_san_cert())
+    ).
+
 san_cert() ->
+    cert_with_extensions([
+        #'Extension'{
+            extnID = ?'id-ce-subjectAltName',
+            extnValue = [
+                {dNSName, "example.com"},
+                {dNSName, "www.example.com"},
+                {iPAddress, [192, 168, 1, 100]},
+                {iPAddress, [32, 1, 13, 184, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]},
+                {rfc822Name, "device@example.com"},
+                {uniformResourceIdentifier, "urn:device:123"}
+            ]
+        }
+    ]).
+
+no_san_cert() ->
+    cert_with_extensions(asn1_NOVALUE).
+
+cert_with_extensions(Extensions) ->
     Key = public_key:generate_key({namedCurve, secp521r1}),
     Subject = {rdnSequence, [
         [
@@ -94,18 +123,6 @@ san_cert() ->
             },
             subjectPublicKey = #'ECPoint'{point = Key#'ECPrivateKey'.publicKey}
         },
-        extensions = [
-            #'Extension'{
-                extnID = ?'id-ce-subjectAltName',
-                extnValue = [
-                    {dNSName, "example.com"},
-                    {dNSName, "www.example.com"},
-                    {iPAddress, [192, 168, 1, 100]},
-                    {iPAddress, [32, 1, 13, 184, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]},
-                    {rfc822Name, "device@example.com"},
-                    {uniformResourceIdentifier, "urn:device:123"}
-                ]
-            }
-        ]
+        extensions = Extensions
     },
     public_key:pkix_sign(TBS, Key).

--- a/test/esockd_ssl_SUITE.erl
+++ b/test/esockd_ssl_SUITE.erl
@@ -64,16 +64,14 @@ t_peer_cert_subject_alt_names(_) ->
         esockd_ssl:peer_cert_subject_alt_names(san_cert())
     ).
 
-t_peer_cert_subject_alt_names_empty(_) ->
+t_peer_cert_subject_alt_names_sparse(Config) ->
     ?assertEqual(
-        #{
-            dns => [],
-            ip => [],
-            email => [],
-            uri => []
-        },
-        esockd_ssl:peer_cert_subject_alt_names(no_san_cert())
+        #{dns => [<<"Server">>, <<"dengzhongwendeMacBook-Pro.local">>, <<"localhost">>]},
+        esockd_ssl:peer_cert_subject_alt_names(cert(Config))
     ).
+
+t_peer_cert_subject_alt_names_empty(_) ->
+    ?assertEqual(nosan, esockd_ssl:peer_cert_subject_alt_names(no_san_cert())).
 
 san_cert() ->
     cert_with_extensions([

--- a/test/esockd_ssl_SUITE.erl
+++ b/test/esockd_ssl_SUITE.erl
@@ -105,7 +105,7 @@ cert_with_extensions(Extensions) ->
         version = v3,
         serialNumber = 1,
         signature = #'SignatureAlgorithm'{
-            algorithm = ?'ecdsa-with-SHA256',
+            algorithm = ?'ecdsa-with-SHA512',
             parameters = Key#'ECPrivateKey'.parameters
         },
         issuer = Subject,

--- a/test/esockd_ssl_SUITE.erl
+++ b/test/esockd_ssl_SUITE.erl
@@ -19,6 +19,7 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
+-include_lib("public_key/include/public_key.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 all() -> esockd_ct:all(?MODULE).
@@ -52,3 +53,59 @@ t_peer_cert_common_name(Config) ->
 t_peer_cert_subject(Config) ->
     esockd_ssl:peer_cert_subject(cert(Config)).
 
+t_peer_cert_subject_alt_names(_) ->
+    ?assertEqual(
+        #{
+            dns => [<<"example.com">>, <<"www.example.com">>],
+            ip => [<<"192.168.1.100">>, <<"2001:db8::1">>],
+            email => [<<"device@example.com">>],
+            uri => [<<"urn:device:123">>]
+        },
+        esockd_ssl:peer_cert_subject_alt_names(san_cert())
+    ).
+
+san_cert() ->
+    Key = public_key:generate_key({namedCurve, secp521r1}),
+    Subject = {rdnSequence, [
+        [
+            #'AttributeTypeAndValue'{
+                type = ?'id-at-commonName',
+                value = {printableString, "SAN Test"}
+            }
+        ]
+    ]},
+    TBS = #'OTPTBSCertificate'{
+        version = v3,
+        serialNumber = 1,
+        signature = #'SignatureAlgorithm'{
+            algorithm = ?'ecdsa-with-SHA256',
+            parameters = Key#'ECPrivateKey'.parameters
+        },
+        issuer = Subject,
+        validity = #'Validity'{
+            notBefore = {generalTime, "20260101000000Z"},
+            notAfter = {generalTime, "20270101000000Z"}
+        },
+        subject = Subject,
+        subjectPublicKeyInfo = #'OTPSubjectPublicKeyInfo'{
+            algorithm = #'PublicKeyAlgorithm'{
+                algorithm = ?'id-ecPublicKey',
+                parameters = Key#'ECPrivateKey'.parameters
+            },
+            subjectPublicKey = #'ECPoint'{point = Key#'ECPrivateKey'.publicKey}
+        },
+        extensions = [
+            #'Extension'{
+                extnID = ?'id-ce-subjectAltName',
+                extnValue = [
+                    {dNSName, "example.com"},
+                    {dNSName, "www.example.com"},
+                    {iPAddress, [192, 168, 1, 100]},
+                    {iPAddress, [32, 1, 13, 184, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]},
+                    {rfc822Name, "device@example.com"},
+                    {uniformResourceIdentifier, "urn:device:123"}
+                ]
+            }
+        ]
+    },
+    public_key:pkix_sign(TBS, Key).


### PR DESCRIPTION
part of https://emqx.atlassian.net/browse/EMQX-15299
## Summary

This adds peer certificate subject alternative name extraction to esockd.

- add `esockd_ssl:peer_cert_subject_alt_names/1` for DER certificate SAN parsing
- add `esockd_peercert:subject_alt_names/1` for `nossl`, direct TLS certs, and PPv2 metadata
- return an empty SAN map for PPv2 metadata because Proxy Protocol v2 does not carry SANs

Checked with:
- `git diff --check`
- `rebar3 ct --suite test/esockd_ssl_SUITE.erl`
- `rebar3 ct --suite test/esockd_peercert_SUITE.erl`