### PR TITLE
fix(udp_proxy): reroute when connection id changes

### DIFF
--- a/src/udp_proxy/esockd_udp_proxy.erl
+++ b/src/udp_proxy/esockd_udp_proxy.erl
@@ -250,20 +250,21 @@ detach(
     } = State,
     Clear
 ) ->
+    ProxyId = self(),
     _ = erlang:demonitor(Ref, [flush]),
 
     Result = esockd_udp_proxy_db:detach(Mod, CId),
-    maybe_detach_connection(Clear, Result, Mod, Pid, CState),
+    maybe_detach_connection(Clear, Result, Mod, Pid, ProxyId, CState),
     State#{connection_id := undefined, connection_pid := undefined, connection_ref := undefined}.
 
-maybe_detach_connection(_Clear, false, _Mod, _Pid, _CState) ->
+maybe_detach_connection(_Clear, false, _Mod, _Pid, _ProxyId, _CState) ->
     ok;
-maybe_detach_connection(Clear, true, Mod, Pid, CState) ->
+maybe_detach_connection(Clear, true, Mod, Pid, ProxyId, CState) ->
     case erlang:is_process_alive(Pid) of
         true when Clear ->
-            esockd_udp_proxy_connection:close(Mod, Pid, CState);
+            esockd_udp_proxy_connection:close(Mod, Pid, ProxyId, CState);
         true ->
-            esockd_udp_proxy_connection:detach(Mod, Pid, CState);
+            esockd_udp_proxy_connection:detach(Mod, Pid, ProxyId, CState);
         _ ->
             ok
     end.

--- a/src/udp_proxy/esockd_udp_proxy.erl
+++ b/src/udp_proxy/esockd_udp_proxy.erl
@@ -253,18 +253,20 @@ detach(
     _ = erlang:demonitor(Ref, [flush]),
 
     Result = esockd_udp_proxy_db:detach(Mod, CId),
-    case Clear andalso Result of
+    maybe_detach_connection(Clear, Result, Mod, Pid, CState),
+    State#{connection_id := undefined, connection_pid := undefined, connection_ref := undefined}.
+
+maybe_detach_connection(_Clear, false, _Mod, _Pid, _CState) ->
+    ok;
+maybe_detach_connection(Clear, true, Mod, Pid, CState) ->
+    case erlang:is_process_alive(Pid) of
+        true when Clear ->
+            esockd_udp_proxy_connection:close(Mod, Pid, CState);
         true ->
-            case erlang:is_process_alive(Pid) of
-                true ->
-                    esockd_udp_proxy_connection:close(Mod, Pid, CState);
-                _ ->
-                    ok
-            end;
+            esockd_udp_proxy_connection:detach(Mod, Pid, CState);
         _ ->
             ok
-    end,
-    State#{connection_id := undefined, connection_pid := undefined, connection_ref := undefined}.
+    end.
 
 -spec socket_exit(state()) -> state().
 socket_exit(State) ->

--- a/src/udp_proxy/esockd_udp_proxy.erl
+++ b/src/udp_proxy/esockd_udp_proxy.erl
@@ -139,10 +139,15 @@ handle_info({ssl_error, _Sock, Reason}, State) ->
 handle_info({ssl_closed, _Sock}, State) ->
     {stop, ssl_closed, socket_exit(State)};
 handle_info(
-    {'DOWN', _, process, _Pid, _Reason},
+    {'DOWN', Ref, process, _Pid, _Reason},
+    #{connection_ref := Ref} = State
+) when is_reference(Ref) ->
+    {stop, {shutdown, connection_closed}, State};
+handle_info(
+    {'DOWN', _Ref, process, _Pid, _Reason},
     State
 ) ->
-    {stop, {shutdown, connection_closed}, State};
+    {noreply, State};
 handle_info(Info, State) ->
     ?ERROR_MSG("Unexpected info: ~p", [Info]),
     {noreply, State}.
@@ -207,8 +212,8 @@ dispatch(
         State
 ) ->
     case lookup(CId, State) of
-        {ok, Pid} ->
-            Result = attach(CId, State, Pid),
+        {ok, Pid, LookupState} ->
+            Result = attach(CId, LookupState, Pid),
             esockd_udp_proxy_connection:dispatch(
                 Mod, Pid, CState, {Transport, Data, Packet}
             ),
@@ -245,7 +250,7 @@ detach(
     } = State,
     Clear
 ) ->
-    erlang:demonitor(Ref),
+    _ = erlang:demonitor(Ref, [flush]),
 
     Result = esockd_udp_proxy_db:detach(Mod, CId),
     case Clear andalso Result of
@@ -270,19 +275,40 @@ heartbeat(Span) ->
     erlang:send_after(timer:seconds(Span), self(), {?FUNCTION_NAME, Span}),
     ok.
 
--spec lookup(connection_id(), state()) -> {ok, pid()} | {error, Reason :: term()}.
-lookup(_CId, #{connection_pid := Pid}) when is_pid(Pid) ->
-    {ok, Pid};
-lookup(CId, #{
-    connection_pid := undefined,
-    connection_mod := Mod,
-    transport := Transport,
-    peer := Peer,
-    connection_options := Opts
-}) ->
+-spec lookup(connection_id(), state()) -> {ok, pid(), state()} | {error, Reason :: term()}.
+lookup(CId, #{connection_id := CId, connection_pid := Pid} = State) when is_pid(Pid) ->
+    {ok, Pid, State};
+lookup(CId, #{connection_pid := Pid} = State) when is_pid(Pid) ->
+    case find_or_create_connection(CId, State) of
+        {ok, NPid} ->
+            {ok, NPid, detach(State, false)};
+        Error ->
+            Error
+    end;
+lookup(
+    CId,
+    #{connection_pid := undefined} = State
+) ->
+    case find_or_create_connection(CId, State) of
+        {ok, Pid} ->
+            {ok, Pid, State};
+        Error ->
+            Error
+    end.
+
+find_or_create_connection(
+    CId,
+    #{
+        connection_mod := Mod,
+        transport := Transport,
+        peer := Peer,
+        connection_options := Opts,
+        connection_state := CState
+    }
+) ->
     %% TODO: use proc_lib:start_link to instead of this call
     Fun = fun() ->
-        esockd_udp_proxy_connection:find_or_create(Mod, CId, Transport, Peer, Opts)
+        esockd_udp_proxy_connection:find_or_create(Mod, CId, Transport, Peer, Opts, CState)
     end,
     case esockd_udp:proxy_request(Fun) of
         {ok, Pid} ->

--- a/src/udp_proxy/esockd_udp_proxy_connection.erl
+++ b/src/udp_proxy/esockd_udp_proxy_connection.erl
@@ -25,7 +25,9 @@
     get_connection_id/5,
     dispatch/4,
     detach/3,
-    close/3
+    detach/4,
+    close/3,
+    close/4
 ]).
 
 -export_type([connection_id/0, connection_module/0]).
@@ -54,11 +56,13 @@
 
 %% Detach Connection
 -callback detach(pid(), connection_state()) -> ok.
+-callback detach(pid(), proxy_id(), connection_state()) -> ok.
 
 %% Close Connection
 -callback close(pid(), connection_state()) -> ok.
+-callback close(pid(), proxy_id(), connection_state()) -> ok.
 
--optional_callbacks([find_or_create/5, detach/2]).
+-optional_callbacks([find_or_create/5, detach/2, detach/3, close/3]).
 
 %%--------------------------------------------------------------------
 %%- API
@@ -83,12 +87,28 @@ get_connection_id(Mod, Transport, Peer, State, Data) ->
 dispatch(Mod, Pid, State, Packet) ->
     Mod:dispatch(Pid, State, Packet).
 
+detach(Mod, Pid, ProxyId, State) ->
+    case erlang:function_exported(Mod, detach, 3) of
+        true ->
+            Mod:detach(Pid, ProxyId, State);
+        false ->
+            detach(Mod, Pid, State)
+    end.
+
 detach(Mod, Pid, State) ->
     case erlang:function_exported(Mod, detach, 2) of
         true ->
             Mod:detach(Pid, State);
         false ->
             ok
+    end.
+
+close(Mod, Pid, ProxyId, State) ->
+    case erlang:function_exported(Mod, close, 3) of
+        true ->
+            Mod:close(Pid, ProxyId, State);
+        false ->
+            close(Mod, Pid, State)
     end.
 
 close(Mod, Pid, State) ->

--- a/src/udp_proxy/esockd_udp_proxy_connection.erl
+++ b/src/udp_proxy/esockd_udp_proxy_connection.erl
@@ -24,6 +24,7 @@
     find_or_create/6,
     get_connection_id/5,
     dispatch/4,
+    detach/3,
     close/3
 ]).
 
@@ -42,8 +43,6 @@
 ) ->
     gen_server:start_ret().
 
--optional_callbacks([find_or_create/5]).
-
 %% Find routing information
 -callback get_connection_id(
     proxy_transport(), peer(), connection_state(), socket_packet()
@@ -53,8 +52,13 @@
 %% Dispacth message
 -callback dispatch(pid(), connection_state(), proxy_packet()) -> ok.
 
+%% Detach Connection
+-callback detach(pid(), connection_state()) -> ok.
+
 %% Close Connection
 -callback close(pid(), connection_state()) -> ok.
+
+-optional_callbacks([find_or_create/5, detach/2]).
 
 %%--------------------------------------------------------------------
 %%- API
@@ -78,6 +82,14 @@ get_connection_id(Mod, Transport, Peer, State, Data) ->
 
 dispatch(Mod, Pid, State, Packet) ->
     Mod:dispatch(Pid, State, Packet).
+
+detach(Mod, Pid, State) ->
+    case erlang:function_exported(Mod, detach, 2) of
+        true ->
+            Mod:detach(Pid, State);
+        false ->
+            ok
+    end.
 
 close(Mod, Pid, State) ->
     Mod:close(Pid, State).

--- a/src/udp_proxy/esockd_udp_proxy_connection.erl
+++ b/src/udp_proxy/esockd_udp_proxy_connection.erl
@@ -21,6 +21,7 @@
 -export([
     initialize/2,
     find_or_create/5,
+    find_or_create/6,
     get_connection_id/5,
     dispatch/4,
     close/3
@@ -36,6 +37,12 @@
 %% Create new connection
 -callback find_or_create(connection_id(), proxy_transport(), peer(), connection_options()) ->
     gen_server:start_ret().
+-callback find_or_create(
+    connection_id(), proxy_transport(), peer(), connection_options(), connection_state()
+) ->
+    gen_server:start_ret().
+
+-optional_callbacks([find_or_create/5]).
 
 %% Find routing information
 -callback get_connection_id(
@@ -57,6 +64,14 @@ initialize(Mod, Opts) ->
 
 find_or_create(Mod, CId, Transport, Peer, Opts) ->
     Mod:find_or_create(CId, Transport, Peer, Opts).
+
+find_or_create(Mod, CId, Transport, Peer, Opts, State) ->
+    case erlang:function_exported(Mod, find_or_create, 5) of
+        true ->
+            Mod:find_or_create(CId, Transport, Peer, Opts, State);
+        false ->
+            Mod:find_or_create(CId, Transport, Peer, Opts)
+    end.
 
 get_connection_id(Mod, Transport, Peer, State, Data) ->
     Mod:get_connection_id(Transport, Peer, State, Data).

--- a/test/esockd_udp_proxy_SUITE.erl
+++ b/test/esockd_udp_proxy_SUITE.erl
@@ -85,13 +85,14 @@ t_reroute_detaches_old_connection_without_closing(_) ->
         ok = gen_udp:send(Sock, {127, 0, 0, 1}, Port, <<"client-a">>),
         PidA = receive_find_or_create(<<"client-a">>),
         receive_dispatch(PidA, <<"client-a">>),
+        ProxyPid = proxy_pid(Srv),
 
         ok = gen_udp:send(Sock, {127, 0, 0, 1}, Port, <<"client-b">>),
         PidB = receive_find_or_create(<<"client-b">>),
         receive_dispatch(PidB, <<"client-b">>),
 
         ?assertNotEqual(PidA, PidB),
-        ?assert(received_detach(PidA)),
+        ?assert(received_detach(PidA, ProxyPid)),
         ?assertNot(received_close(PidA))
     after
         gen_udp:close(Sock),
@@ -124,7 +125,7 @@ t_lookup_failure_preserves_old_binding(_) ->
         receive_find_or_create_ignored(<<"ignore">>),
 
         ok = esockd_udp_proxy:close(ProxyPid),
-        ?assert(received_close(PidA))
+        ?assert(received_close(PidA, ProxyPid))
     after
         gen_udp:close(Sock),
         erlang:is_process_alive(Srv) andalso esockd_udp:stop(Srv)
@@ -211,6 +212,18 @@ t_legacy_find_or_create_wrapper_still_works(_) ->
         persistent_term:erase({esockd_udp_proxy_legacy_conn, test_parent})
     end.
 
+t_legacy_detach_wrapper_still_works(_) ->
+    Pid = spawn(fun connection_loop/0),
+    State = #{parent => self()},
+    ok = esockd_udp_proxy_connection:detach(?MODULE, Pid, State),
+    ?assert(received_legacy_detach(Pid)).
+
+t_legacy_close_wrapper_still_works(_) ->
+    Pid = spawn(fun connection_loop/0),
+    State = #{parent => self()},
+    ok = esockd_udp_proxy_connection:close(?MODULE, Pid, State),
+    ?assert(received_legacy_close(Pid)).
+
 %%--------------------------------------------------------------------
 %% esockd_udp_proxy_connection callbacks
 %%--------------------------------------------------------------------
@@ -239,12 +252,22 @@ dispatch(Pid, State, {_Transport, _Data, Packet}) ->
     ok.
 
 close(Pid, State) ->
-    maps:get(parent, State) ! {close, Pid},
+    maps:get(parent, State) ! {legacy_close, Pid},
+    Pid ! close,
+    ok.
+
+close(Pid, ProxyPid, State) ->
+    maps:get(parent, State) ! {close, Pid, ProxyPid},
     Pid ! close,
     ok.
 
 detach(Pid, State) ->
-    maps:get(parent, State) ! {detach, Pid},
+    maps:get(parent, State) ! {legacy_detach, Pid},
+    Pid ! detach,
+    ok.
+
+detach(Pid, ProxyPid, State) ->
+    maps:get(parent, State) ! {detach, Pid, ProxyPid},
     Pid ! detach,
     ok.
 
@@ -319,9 +342,41 @@ received_close(Pid) ->
         false
     end.
 
+received_close(Pid, ProxyPid) ->
+    receive
+        {close, Pid, ProxyPid} ->
+            true
+    after 100 ->
+        false
+    end.
+
+received_legacy_close(Pid) ->
+    receive
+        {legacy_close, Pid} ->
+            true
+    after 100 ->
+        false
+    end.
+
 received_detach(Pid) ->
     receive
         {detach, Pid} ->
+            true
+    after 100 ->
+        false
+    end.
+
+received_detach(Pid, ProxyPid) ->
+    receive
+        {detach, Pid, ProxyPid} ->
+            true
+    after 100 ->
+        false
+    end.
+
+received_legacy_detach(Pid) ->
+    receive
+        {legacy_detach, Pid} ->
             true
     after 100 ->
         false

--- a/test/esockd_udp_proxy_SUITE.erl
+++ b/test/esockd_udp_proxy_SUITE.erl
@@ -1,0 +1,282 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(esockd_udp_proxy_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include("include/esockd_proxy.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+all() -> esockd_ct:all(?MODULE).
+
+%%--------------------------------------------------------------------
+%% Test cases for UDP proxy
+%%--------------------------------------------------------------------
+
+t_reroute_when_connection_id_changes(_) ->
+    process_flag(trap_exit, true),
+    ensure_proxy_db(),
+    Port = pick_udp_port(),
+    ProxyOpts = #{
+        test_parent => self(),
+        esockd_proxy_opts => #{connection_mod => ?MODULE}
+    },
+    {ok, Srv} = esockd_udp:server(
+        test_udp_proxy,
+        {{127, 0, 0, 1}, Port},
+        [
+            {connection_mfargs, {esockd_udp_proxy, start_link, [ProxyOpts]}}
+        ]
+    ),
+    {ok, Sock} = gen_udp:open(0, [binary, {active, false}]),
+    try
+        ok = gen_udp:send(Sock, {127, 0, 0, 1}, Port, <<"client-a">>),
+        PidA = receive_find_or_create(<<"client-a">>),
+        receive_dispatch(PidA, <<"client-a">>),
+
+        ok = gen_udp:send(Sock, {127, 0, 0, 1}, Port, <<"client-a">>),
+        receive_dispatch(PidA, <<"client-a">>),
+        ?assertNot(received_find_or_create()),
+
+        ok = gen_udp:send(Sock, {127, 0, 0, 1}, Port, <<"client-b">>),
+        PidB = receive_find_or_create(<<"client-b">>),
+        receive_dispatch(PidB, <<"client-b">>),
+
+        ?assertNotEqual(PidA, PidB),
+        ?assert(is_process_alive(PidA)),
+        ?assertNot(received_close(PidA))
+    after
+        gen_udp:close(Sock),
+        erlang:is_process_alive(Srv) andalso esockd_udp:stop(Srv)
+    end.
+
+t_lookup_failure_preserves_old_binding(_) ->
+    process_flag(trap_exit, true),
+    ensure_proxy_db(),
+    Port = pick_udp_port(),
+    ProxyOpts = #{
+        test_parent => self(),
+        esockd_proxy_opts => #{connection_mod => ?MODULE}
+    },
+    {ok, Srv} = esockd_udp:server(
+        test_udp_proxy_lookup_failure,
+        {{127, 0, 0, 1}, Port},
+        [
+            {connection_mfargs, {esockd_udp_proxy, start_link, [ProxyOpts]}}
+        ]
+    ),
+    {ok, Sock} = gen_udp:open(0, [binary, {active, false}]),
+    try
+        ok = gen_udp:send(Sock, {127, 0, 0, 1}, Port, <<"client-a">>),
+        PidA = receive_find_or_create(<<"client-a">>),
+        receive_dispatch(PidA, <<"client-a">>),
+        ProxyPid = proxy_pid(Srv),
+
+        ok = gen_udp:send(Sock, {127, 0, 0, 1}, Port, <<"ignore">>),
+        receive_find_or_create_ignored(<<"ignore">>),
+
+        ok = esockd_udp_proxy:close(ProxyPid),
+        ?assert(received_close(PidA))
+    after
+        gen_udp:close(Sock),
+        erlang:is_process_alive(Srv) andalso esockd_udp:stop(Srv)
+    end.
+
+t_stale_down_after_reroute_is_ignored(_) ->
+    process_flag(trap_exit, true),
+    ensure_proxy_db(),
+    Port = pick_udp_port(),
+    ProxyOpts = #{
+        test_parent => self(),
+        esockd_proxy_opts => #{connection_mod => ?MODULE}
+    },
+    {ok, Srv} = esockd_udp:server(
+        test_udp_proxy_stale_down,
+        {{127, 0, 0, 1}, Port},
+        [
+            {connection_mfargs, {esockd_udp_proxy, start_link, [ProxyOpts]}}
+        ]
+    ),
+    {ok, Sock} = gen_udp:open(0, [binary, {active, false}]),
+    try
+        ok = gen_udp:send(Sock, {127, 0, 0, 1}, Port, <<"client-a">>),
+        PidA = receive_find_or_create(<<"client-a">>),
+        receive_dispatch(PidA, <<"client-a">>),
+        ProxyPid = proxy_pid(Srv),
+        #{connection_ref := RefA} = sys:get_state(ProxyPid),
+
+        ok = gen_udp:send(Sock, {127, 0, 0, 1}, Port, <<"client-b">>),
+        PidB = receive_find_or_create(<<"client-b">>),
+        receive_dispatch(PidB, <<"client-b">>),
+
+        ProxyPid ! {'DOWN', RefA, process, PidA, normal},
+        timer:sleep(100),
+        ?assert(is_process_alive(ProxyPid)),
+
+        ok = gen_udp:send(Sock, {127, 0, 0, 1}, Port, <<"client-b">>),
+        receive_dispatch(PidB, <<"client-b">>)
+    after
+        gen_udp:close(Sock),
+        erlang:is_process_alive(Srv) andalso esockd_udp:stop(Srv)
+    end.
+
+t_legacy_find_or_create_callback_still_works(_) ->
+    process_flag(trap_exit, true),
+    ensure_proxy_db(),
+    Port = pick_udp_port(),
+    persistent_term:put({esockd_udp_proxy_legacy_conn, test_parent}, self()),
+    ProxyOpts = #{
+        test_parent => self(),
+        esockd_proxy_opts => #{connection_mod => esockd_udp_proxy_legacy_conn}
+    },
+    {ok, Srv} = esockd_udp:server(
+        test_udp_proxy_legacy,
+        {{127, 0, 0, 1}, Port},
+        [
+            {connection_mfargs, {esockd_udp_proxy, start_link, [ProxyOpts]}}
+        ]
+    ),
+    {ok, Sock} = gen_udp:open(0, [binary, {active, false}]),
+    try
+        ok = gen_udp:send(Sock, {127, 0, 0, 1}, Port, <<"client-a">>),
+        PidA = receive_find_or_create(<<"client-a">>),
+        receive_dispatch(PidA, <<"client-a">>)
+    after
+        gen_udp:close(Sock),
+        erlang:is_process_alive(Srv) andalso esockd_udp:stop(Srv),
+        persistent_term:erase({esockd_udp_proxy_legacy_conn, test_parent})
+    end.
+
+t_legacy_find_or_create_wrapper_still_works(_) ->
+    persistent_term:put({esockd_udp_proxy_legacy_conn, test_parent}, self()),
+    try
+        {ok, Pid} = esockd_udp_proxy_connection:find_or_create(
+            esockd_udp_proxy_legacy_conn,
+            <<"client-a">>,
+            {?PROXY_TRANSPORT, self(), self()},
+            {127, 0, 0, 1},
+            #{}
+        ),
+        ?assertEqual(Pid, receive_find_or_create(<<"client-a">>)),
+        Pid ! close
+    after
+        persistent_term:erase({esockd_udp_proxy_legacy_conn, test_parent})
+    end.
+
+%%--------------------------------------------------------------------
+%% esockd_udp_proxy_connection callbacks
+%%--------------------------------------------------------------------
+
+initialize(Opts) ->
+    #{parent => maps:get(test_parent, Opts)}.
+
+get_connection_id(_Transport, _Peer, State, Data) ->
+    {ok, Data, Data, State#{last_cid => Data}}.
+
+find_or_create(CId, _Transport, _Peer, _Opts, State) ->
+    Parent = maps:get(parent, State),
+    case CId of
+        <<"ignore">> ->
+            Parent ! {find_or_create_ignored, CId},
+            ignore;
+        _ ->
+            Pid = spawn(fun connection_loop/0),
+            Parent ! {find_or_create, CId, maps:get(last_cid, State), Pid},
+            {ok, Pid}
+    end.
+
+dispatch(Pid, State, {_Transport, _Data, Packet}) ->
+    maps:get(parent, State) ! {dispatch, Pid, Packet},
+    Pid ! {packet, Packet},
+    ok.
+
+close(Pid, State) ->
+    maps:get(parent, State) ! {close, Pid},
+    Pid ! close,
+    ok.
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+ensure_proxy_db() ->
+    case whereis(esockd_udp_proxy_db) of
+        undefined ->
+            {ok, _Pid} = esockd_udp_proxy_db:start_link(),
+            ok;
+        _Pid ->
+            ok
+    end.
+
+pick_udp_port() ->
+    {ok, Sock} = gen_udp:open(0, [binary]),
+    {ok, Port} = inet:port(Sock),
+    gen_udp:close(Sock),
+    Port.
+
+proxy_pid(Srv) ->
+    [{undefined, Pid, worker, [esockd_udp_proxy]}] = gen_server:call(Srv, which_children),
+    Pid.
+
+connection_loop() ->
+    receive
+        close ->
+            ok;
+        _Msg ->
+            connection_loop()
+    end.
+
+receive_find_or_create(CId) ->
+    receive
+        {find_or_create, CId, CId, Pid} ->
+            Pid
+    after 1000 ->
+        error({missing_find_or_create, CId})
+    end.
+
+receive_dispatch(Pid, Packet) ->
+    receive
+        {dispatch, Pid, Packet} ->
+            ok
+    after 1000 ->
+        error({missing_dispatch, Pid, Packet})
+    end.
+
+received_find_or_create() ->
+    receive
+        {find_or_create, _CId, _LastCId, _Pid} ->
+            true
+    after 100 ->
+        false
+    end.
+
+receive_find_or_create_ignored(CId) ->
+    receive
+        {find_or_create_ignored, CId} ->
+            ok
+    after 1000 ->
+        error({missing_find_or_create_ignored, CId})
+    end.
+
+received_close(Pid) ->
+    receive
+        {close, Pid} ->
+            true
+    after 100 ->
+        false
+    end.

--- a/test/esockd_udp_proxy_SUITE.erl
+++ b/test/esockd_udp_proxy_SUITE.erl
@@ -65,6 +65,39 @@ t_reroute_when_connection_id_changes(_) ->
         erlang:is_process_alive(Srv) andalso esockd_udp:stop(Srv)
     end.
 
+t_reroute_detaches_old_connection_without_closing(_) ->
+    process_flag(trap_exit, true),
+    ensure_proxy_db(),
+    Port = pick_udp_port(),
+    ProxyOpts = #{
+        test_parent => self(),
+        esockd_proxy_opts => #{connection_mod => ?MODULE}
+    },
+    {ok, Srv} = esockd_udp:server(
+        test_udp_proxy_detach_on_reroute,
+        {{127, 0, 0, 1}, Port},
+        [
+            {connection_mfargs, {esockd_udp_proxy, start_link, [ProxyOpts]}}
+        ]
+    ),
+    {ok, Sock} = gen_udp:open(0, [binary, {active, false}]),
+    try
+        ok = gen_udp:send(Sock, {127, 0, 0, 1}, Port, <<"client-a">>),
+        PidA = receive_find_or_create(<<"client-a">>),
+        receive_dispatch(PidA, <<"client-a">>),
+
+        ok = gen_udp:send(Sock, {127, 0, 0, 1}, Port, <<"client-b">>),
+        PidB = receive_find_or_create(<<"client-b">>),
+        receive_dispatch(PidB, <<"client-b">>),
+
+        ?assertNotEqual(PidA, PidB),
+        ?assert(received_detach(PidA)),
+        ?assertNot(received_close(PidA))
+    after
+        gen_udp:close(Sock),
+        erlang:is_process_alive(Srv) andalso esockd_udp:stop(Srv)
+    end.
+
 t_lookup_failure_preserves_old_binding(_) ->
     process_flag(trap_exit, true),
     ensure_proxy_db(),
@@ -210,6 +243,11 @@ close(Pid, State) ->
     Pid ! close,
     ok.
 
+detach(Pid, State) ->
+    maps:get(parent, State) ! {detach, Pid},
+    Pid ! detach,
+    ok.
+
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
@@ -276,6 +314,14 @@ receive_find_or_create_ignored(CId) ->
 received_close(Pid) ->
     receive
         {close, Pid} ->
+            true
+    after 100 ->
+        false
+    end.
+
+received_detach(Pid) ->
+    receive
+        {detach, Pid} ->
             true
     after 100 ->
         false

--- a/test/esockd_udp_proxy_legacy_conn.erl
+++ b/test/esockd_udp_proxy_legacy_conn.erl
@@ -1,0 +1,51 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(esockd_udp_proxy_legacy_conn).
+
+-export([initialize/1, find_or_create/4, get_connection_id/4, dispatch/3, close/2]).
+
+initialize(Opts) ->
+    #{parent => maps:get(test_parent, Opts)}.
+
+get_connection_id(_Transport, _Peer, State, Data) ->
+    {ok, Data, Data, State#{last_cid => Data}}.
+
+find_or_create(CId, _Transport, _Peer, _Opts) ->
+    Pid = spawn(fun connection_loop/0),
+    test_parent() ! {find_or_create, CId, CId, Pid},
+    {ok, Pid}.
+
+dispatch(Pid, State, {_Transport, _Data, Packet}) ->
+    maps:get(parent, State) ! {dispatch, Pid, Packet},
+    Pid ! {packet, Packet},
+    ok.
+
+close(Pid, State) ->
+    maps:get(parent, State) ! {close, Pid},
+    Pid ! close,
+    ok.
+
+test_parent() ->
+    persistent_term:get({?MODULE, test_parent}).
+
+connection_loop() ->
+    receive
+        close ->
+            ok;
+        _Msg ->
+            connection_loop()
+    end.


### PR DESCRIPTION
## Summary

- reroute an existing UDP proxy when a later datagram resolves to a different logical connection id
- detach the old proxy mapping only after the new id resolves successfully
- pass the current proxy pid to callback modules through optional owner-aware `detach/3` and `close/3` callbacks
- keep the old binding intact if resolving the new connection id fails
- ignore stale monitor `DOWN` messages after a proxy has been rebound to another connection
- add an optional `find_or_create/5` callback that receives the proxy connection state
- keep the existing `find_or_create/4`, `detach/2`, `close/2`, and exported wrapper paths for backward compatibility

## Why

`esockd_udp` routes UDP datagrams by source peer tuple to a proxy process while that proxy process is alive. `esockd_udp_proxy` then parses each datagram to obtain a protocol-level connection id. In the previous implementation, once a proxy process had attached to a connection pid, later datagrams from the same UDP peer were always dispatched to that cached pid, even if parsing the datagram returned a different connection id.

That makes the UDP source tuple stronger than the protocol-level connection id. This is a generic UDP proxy issue, not a protocol-specific behavior: any UDP protocol that derives logical identity from packet content can see a different logical connection id from the same peer tuple, for example when a NAT mapping or client port is reused before the old proxy process exits.

When the parsed connection id changes, the proxy should stop using the cached connection pid for the old id and resolve the new id normally. The old logical connection must not be closed just because the transport proxy is being rebound, so this PR detaches the old mapping without closing the old pid. Modules that need to react to that transport detach can implement `detach/3` and receive the exact proxy pid that detached them. Modules that only need the previous behavior can keep `detach/2` or omit detach handling.

MQTT-SN is one concrete caller that exposes this problem because its stable logical identity is the ClientId carried in packets, while UDP source tuples can change or be reused independently. The fix itself stays in `esockd_udp_proxy` and does not encode MQTT-SN-specific rules.

## Compatibility

Existing behavior is preserved when the parsed connection id is unchanged: the proxy keeps the cached pid fast path.

Callback modules that only implement `find_or_create/4` continue to work. Modules that need packet-parse state can opt in to `find_or_create/5`; otherwise the wrapper falls back to `find_or_create/4`.

Callback modules that only implement `detach/2` and `close/2` continue to work. Owner-aware `detach/3` and `close/3` are optional. The old exported wrappers `esockd_udp_proxy_connection:detach/3` and `close/3` are also kept.

## Tests

- `rebar3 ct --suite test/esockd_udp_proxy_SUITE.erl`
