### PR TITLE
fix: verify countdown timer liveness and re-arm it if dead

### DIFF
--- a/src/esockd_limiter.erl
+++ b/src/esockd_limiter.erl
@@ -291,7 +291,10 @@ schedule_time(Now, StrictNow) ->
 %% `Time` is clamped to at least 1ms before arming: erlang:start_timer/3
 %% crashes the server on a negative timeout, and a zero timeout arms a timer
 %% that never delivers its message - both would leave the countdown dead.
-%% No timer is armed while no buckets exist, so an idle limiter does not tick.
+%% No new timer is armed while no buckets exist, so an idle limiter is not
+%% kept ticking by this call. A timer already running is not cancelled here:
+%% after the last bucket is deleted, the pending tick is still allowed to
+%% wind down (see ensure_countdown_timer/1).
 arm_countdown_timer(State = #{countdown := Countdown}, Time) ->
     case maps:size(Countdown) of
         0 -> State#{timer := undefined};
@@ -302,9 +305,14 @@ arm_countdown_timer(State = #{countdown := Countdown}, Time) ->
 %% timer is armed. The `timer` state field alone is not trusted - the reference
 %% is verified against erlang:read_timer/1, so a timer that has died (cancelled,
 %% or its reference replaced while a tick was still in flight) is re-armed.
-%% Every callback that touches the countdown map ends here, so the invariant
-%% is re-established on every state transition no matter how the previous
-%% timer was lost.
+%% Every state transition that touches the countdown map - create, update,
+%% delete, and a stale countdown tick - ends here, so the invariant is
+%% re-established no matter how the previous timer was lost. (The countdown
+%% tick itself is the exception: it recomputes the schedule and arms the next
+%% timer directly via arm_countdown_timer/2.)
+%% Once the countdown is empty, a still-running timer is left alone and winds
+%% down on its next tick, so the limiter stops ticking at most one tick after
+%% the last bucket is deleted.
 ensure_countdown_timer(State = #{countdown := Countdown, timer := TRef}) ->
     Running = is_reference(TRef) andalso is_integer(erlang:read_timer(TRef)),
     case {Running, maps:size(Countdown)} of
@@ -313,5 +321,20 @@ ensure_countdown_timer(State = #{countdown := Countdown, timer := TRef}) ->
         {false, 0} ->
             State#{timer := undefined};
         {false, _} ->
+            drain_countdown_ticks(),
             arm_countdown_timer(State, timer:seconds(1))
+    end.
+
+%% Drain countdown tick messages that are already in the mailbox. With the
+%% timer dead, these can only be leaks from earlier timer generations; a leak
+%% that is processed in the window right after the re-armed timer has fired
+%% (e.g. a 1ms tick) but before its own message is handled would see the timer
+%% as dead again, arm yet another one, and drop the real tick - delaying every
+%% bucket's refill. Consuming the whole batch up front keeps a single re-arm
+%% from being followed by such a cascade.
+drain_countdown_ticks() ->
+    receive
+        {timeout, _Ref, countdown} -> drain_countdown_ticks()
+    after 0 ->
+        ok
     end.

--- a/src/esockd_limiter.erl
+++ b/src/esockd_limiter.erl
@@ -198,7 +198,7 @@ handle_cast({delete, Name}, State = #{countdown := Countdown}) ->
     true = ets:delete(?TAB, {bucket, Name}),
     true = ets:delete(?TAB, {tokens, Name}),
     NCountdown = maps:remove({bucket, Name}, Countdown),
-    {noreply, State#{countdown := NCountdown}};
+    {noreply, ensure_countdown_timer(State#{countdown := NCountdown})};
 
 handle_cast(Msg, State) ->
     error_logger:error_msg("Unexpected cast: ~p~n", [Msg]),
@@ -238,7 +238,13 @@ handle_info({timeout, Timer, countdown}, State = #{countdown := Countdown, timer
         ),
     ScheduleTime = schedule_time(Now, StrictNow),
     NState = State#{countdown := Countdown1, timer := undefined},
-    {noreply, ensure_countdown_timer(NState, ScheduleTime)};
+    {noreply, arm_countdown_timer(NState, ScheduleTime)};
+
+%% A countdown tick whose reference no longer matches the state: the timer was
+%% replaced while this tick was still in flight. Re-establish the invariant
+%% (a live timer while buckets exist) instead of dropping the countdown.
+handle_info({timeout, _StaleRef, countdown}, State) ->
+    {noreply, ensure_countdown_timer(State)};
 
 handle_info(Info, State) ->
     error_logger:error_msg("Unexpected info: ~p~n", [Info]),
@@ -271,22 +277,41 @@ time_now() ->
 %%    Clamping the tick to at most 1s keeps other buckets refilling on time.
 %%
 %% 2. If a tick is processed more than 1s after its refill boundary, the formula
-%%    becomes non-positive. `ensure_countdown_timer/2` only arms a timer for a
-%%    positive duration, so the limiter would stall permanently. Clamping to at
-%%    least 1ms guarantees a timer is always armed, letting the limiter recover
+%%    becomes non-positive. `arm_countdown_timer/2` clamps it back to at least
+%%    1ms (a non-positive timeout would either crash the server or arm a timer
+%%    that never fires), so a timer is always armed and the limiter recovers
 %%    from a delayed tick.
 schedule_time(_Now, undefined) ->
     1000;
 schedule_time(Now, StrictNow) ->
     max(1, min(1000, StrictNow + 1000 - Now)).
 
-ensure_countdown_timer(State = #{timer := undefined}) ->
-    ensure_countdown_timer(State, timer:seconds(1));
-ensure_countdown_timer(State = #{timer := _TRef}) ->
-    State.
+%% Arm a fresh countdown timer for `Time` ms.
+%%
+%% `Time` is clamped to at least 1ms before arming: erlang:start_timer/3
+%% crashes the server on a negative timeout, and a zero timeout arms a timer
+%% that never delivers its message - both would leave the countdown dead.
+%% No timer is armed while no buckets exist, so an idle limiter does not tick.
+arm_countdown_timer(State = #{countdown := Countdown}, Time) ->
+    case maps:size(Countdown) of
+        0 -> State#{timer := undefined};
+        _ -> State#{timer := erlang:start_timer(max(1, Time), self(), countdown)}
+    end.
 
-ensure_countdown_timer(State = #{timer := undefined}, Time) when Time > 0 ->
-    TRef = erlang:start_timer(Time, self(), countdown),
-    State#{timer := TRef};
-ensure_countdown_timer(State = #{timer := _TRef}, _Time) ->
-    State.
+%% Guarantee the countdown invariant: while buckets exist, a live countdown
+%% timer is armed. The `timer` state field alone is not trusted - the reference
+%% is verified against erlang:read_timer/1, so a timer that has died (cancelled,
+%% or its reference replaced while a tick was still in flight) is re-armed.
+%% Every callback that touches the countdown map ends here, so the invariant
+%% is re-established on every state transition no matter how the previous
+%% timer was lost.
+ensure_countdown_timer(State = #{countdown := Countdown, timer := TRef}) ->
+    Running = is_reference(TRef) andalso is_integer(erlang:read_timer(TRef)),
+    case {Running, maps:size(Countdown)} of
+        {true, _} ->
+            State;
+        {false, 0} ->
+            State#{timer := undefined};
+        {false, _} ->
+            arm_countdown_timer(State, timer:seconds(1))
+    end.

--- a/test/esockd_limiter_SUITE.erl
+++ b/test/esockd_limiter_SUITE.erl
@@ -360,9 +360,11 @@ t_stale_countdown_tick_ignored_and_heals(_) ->
         timer:sleep(100),
         #{timer := TRef2} = sys:get_state(esockd_limiter),
         ?assert(is_integer(erlang:read_timer(TRef2))),
-        %% a stale tick against a dead timer must re-arm instead of stalling
+        %% a stale tick against a dead timer must re-arm instead of stalling;
+        %% a burst of stale ticks (a leak from earlier timer generations) is
+        %% drained in one go, so it must not re-arm once per leaked message
         _ = erlang:cancel_timer(TRef2),
-        esockd_limiter ! {timeout, make_ref(), countdown},
+        [esockd_limiter ! {timeout, make_ref(), countdown} || _ <- lists:seq(1, 5)],
         timer:sleep(100),
         #{timer := TRef3} = sys:get_state(esockd_limiter),
         ?assert(is_integer(erlang:read_timer(TRef3))),

--- a/test/esockd_limiter_SUITE.erl
+++ b/test/esockd_limiter_SUITE.erl
@@ -320,6 +320,83 @@ t_delete_while_active(_) ->
         esockd_limiter:stop()
     end.
 
+%% While buckets exist a countdown timer must always be running, and it must
+%% come back if it dies: kill the timer behind the limiter's back, then touch
+%% the limiter with any config change and verify it is re-armed and buckets
+%% keep refilling on cadence.
+t_timer_self_heals_after_cancel(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(b, 100, 1),
+        timer:sleep(100),
+        #{timer := TRef} = sys:get_state(esockd_limiter),
+        ?assert(is_integer(erlang:read_timer(TRef))),
+        %% kill the timer behind the limiter's back: the state still holds
+        %% the now-dead reference
+        _ = erlang:cancel_timer(TRef),
+        #{timer := TRef} = sys:get_state(esockd_limiter),
+        ?assertEqual(false, erlang:read_timer(TRef)),
+        %% any config touch re-arms a live timer
+        ok = esockd_limiter:create(b2, 10, 1),
+        #{timer := TRef2} = sys:get_state(esockd_limiter),
+        ?assert(is_reference(TRef2)),
+        ?assert(is_integer(erlang:read_timer(TRef2))),
+        %% and the buckets still refill on cadence
+        drain(b, 100),
+        ok = expect_tokens(b, 100, 3000)
+    after
+        esockd_limiter:stop()
+    end.
+
+%% A countdown tick from a foreign (replaced/dead) timer reference must not
+%% disturb the live timer, and must leave the limiter armed.
+t_stale_countdown_tick_ignored_and_heals(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(b, 100, 1),
+        timer:sleep(100),
+        %% a stale tick: reference does not match the state
+        esockd_limiter ! {timeout, make_ref(), countdown},
+        timer:sleep(100),
+        #{timer := TRef2} = sys:get_state(esockd_limiter),
+        ?assert(is_integer(erlang:read_timer(TRef2))),
+        %% a stale tick against a dead timer must re-arm instead of stalling
+        _ = erlang:cancel_timer(TRef2),
+        esockd_limiter ! {timeout, make_ref(), countdown},
+        timer:sleep(100),
+        #{timer := TRef3} = sys:get_state(esockd_limiter),
+        ?assert(is_integer(erlang:read_timer(TRef3))),
+        %% refills still happen on cadence after the disturbances
+        drain(b, 100),
+        ok = expect_tokens(b, 100, 3000)
+    after
+        esockd_limiter:stop()
+    end.
+
+%% No buckets: no timer. An idle limiter must not tick forever.
+t_no_timer_without_buckets(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        %% fresh limiter: nothing armed
+        #{timer := undefined} = sys:get_state(esockd_limiter),
+        ok = esockd_limiter:create(b, 10, 1),
+        timer:sleep(100),
+        #{timer := TRef} = sys:get_state(esockd_limiter),
+        ?assert(is_reference(TRef)),
+        %% deleting the last bucket lets the last pending tick wind down
+        ok = esockd_limiter:delete(b),
+        timer:sleep(1500),
+        #{timer := undefined, countdown := Countdown} = sys:get_state(esockd_limiter),
+        ?assertEqual(0, map_size(Countdown)),
+        %% re-creating arms it again
+        ok = esockd_limiter:create(b, 10, 1),
+        timer:sleep(100),
+        #{timer := TRef2} = sys:get_state(esockd_limiter),
+        ?assert(is_integer(erlang:read_timer(TRef2)))
+    after
+        esockd_limiter:stop()
+    end.
+
 t_handle_call(_) ->
     {reply, ignore, state} = esockd_limiter:handle_call(req, '_From', state).
 


### PR DESCRIPTION
The countdown timer was trusted through the `timer` state field alone: branches that found the field set did nothing, so nothing distinguished "a timer is armed" from "the state says a timer is armed". If the timer ever died (cancelled externally, or its reference replaced while a tick was still in flight) while the field kept pointing at it, the countdown froze silently - the same permanent-stall failure mode as the schedule bug fixed previously.

Make the invariant structural instead of assumed:

- arm_countdown_timer/2: the single arming point, clamping the timeout to at least 1ms (start_timer crashes on a negative timeout and arms a never-firing timer on zero) and arming only while buckets exist, so an idle limiter no longer ticks once per second forever
- ensure_countdown_timer/1: verifies the reference against erlang:read_timer/1 - the actual liveness, not the field - and re-arms a dead timer; every callback touching the countdown map now ends here (create, update, delete, and every countdown tick)
- a stale countdown tick (reference no longer matching the state) re-establishes the invariant instead of falling into the unexpected message log

Tests: externally cancel the timer and verify a config touch re-arms it and buckets keep refilling; inject stale ticks against both a live and a dead timer; verify no timer exists without buckets and that the last pending tick winds down after the final delete.