### PR TITLE
fix: migrate limiter countdown clamp and timer watchdog fixes to master

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -27,7 +27,7 @@
 {profiles,
     [{test,
         [{deps, [{meck, "0.8.13"}]},
-         {erl_opts, [debug_info]},
+         {erl_opts, [{d, 'TEST'}, debug_info]},
          {extra_src_dirs,
             ["examples/client",
              "examples/active_n",

--- a/src/esockd_limiter.erl
+++ b/src/esockd_limiter.erl
@@ -78,7 +78,10 @@ bucket_info({{bucket, Name}, Capacity, Interval, LastTime}) ->
      }.
 
 tokens(Name) ->
-    ets:lookup_element(?TAB, {tokens, Name}, 2).
+    case ets:lookup(?TAB, {tokens, Name}) of
+        [] -> 0; %% the bucket is being deleted concurrently; report a stale 0 instead of crashing
+        [{_, Tokens}] -> Tokens
+    end.
 
 -spec(stop() -> ok).
 stop() ->
@@ -253,10 +256,29 @@ code_change(_OldVsn, State, _Extra) ->
 time_now() ->
     erlang:system_time(millisecond).
 
+%% The countdown ticks must fire roughly once per second: every bucket's
+%% countdown is decremented once per tick, so a tick longer than 1s slows down
+%% the token refill of every bucket.
+%%
+%% Two failure modes of the un-clamped `StrictNow + 1000 - Now` are avoided:
+%%
+%% 1. When a bucket's countdown reaches 1 well before `LastTime + Interval * 1000`
+%%    (e.g. it was re-configured to a larger interval while its countdown was
+%%    already low), the bucket refills "early", pushing `StrictNow` far into
+%%    the future. Since all buckets share a single timer, the next tick would
+%%    be delayed by ~Interval seconds, starving every other bucket (e.g. a
+%%    1-second conn-rate limiter). Clamping the tick to at most 1s keeps other
+%%    buckets refilling on time.
+%%
+%% 2. If a tick is processed more than 1s after its refill boundary, the formula
+%%    becomes non-positive. `ensure_countdown_timer/2` only arms a timer for a
+%%    positive duration, so the limiter would stall permanently. Clamping to at
+%%    least 1ms guarantees a timer is always armed, letting the limiter recover
+%%    from a delayed tick.
 schedule_time(_Now, undefined) ->
     1000;
 schedule_time(Now, StrictNow) ->
-    StrictNow + 1000 - Now.
+    max(1, min(1000, StrictNow + 1000 - Now)).
 
 ensure_countdown_timer(State = #{timer := undefined}) ->
     ensure_countdown_timer(State, timer:seconds(1));

--- a/src/esockd_limiter.erl
+++ b/src/esockd_limiter.erl
@@ -197,7 +197,7 @@ handle_cast({delete, Name}, State = #{countdown := Countdown}) ->
     true = ets:delete(?TAB, {bucket, Name}),
     true = ets:delete(?TAB, {tokens, Name}),
     NCountdown = maps:remove({bucket, Name}, Countdown),
-    {noreply, State#{countdown := NCountdown}};
+    {noreply, ensure_countdown_timer(State#{countdown := NCountdown})};
 
 handle_cast(Msg, State) ->
     error_logger:error_msg("Unexpected cast: ~p~n", [Msg]),
@@ -237,7 +237,13 @@ handle_info({timeout, Timer, countdown}, State = #{countdown := Countdown, timer
         ),
     ScheduleTime = schedule_time(Now, StrictNow),
     NState = State#{countdown := Countdown1, timer := undefined},
-    {noreply, ensure_countdown_timer(NState, ScheduleTime)};
+    {noreply, arm_countdown_timer(NState, ScheduleTime)};
+
+%% A countdown tick whose reference no longer matches the state: the timer was
+%% replaced while this tick was still in flight. Re-establish the invariant
+%% (a live timer while buckets exist) instead of dropping the countdown.
+handle_info({timeout, _StaleRef, countdown}, State) ->
+    {noreply, ensure_countdown_timer(State)};
 
 handle_info(Info, State) ->
     error_logger:error_msg("Unexpected info: ~p~n", [Info]),
@@ -271,22 +277,64 @@ time_now() ->
 %%    buckets refilling on time.
 %%
 %% 2. If a tick is processed more than 1s after its refill boundary, the formula
-%%    becomes non-positive. `ensure_countdown_timer/2` only arms a timer for a
-%%    positive duration, so the limiter would stall permanently. Clamping to at
-%%    least 1ms guarantees a timer is always armed, letting the limiter recover
+%%    becomes non-positive. `arm_countdown_timer/2` clamps it back to at least
+%%    1ms (a non-positive timeout would either crash the server or arm a timer
+%%    that never fires), so a timer is always armed and the limiter recovers
 %%    from a delayed tick.
 schedule_time(_Now, undefined) ->
     1000;
 schedule_time(Now, StrictNow) ->
     max(1, min(1000, StrictNow + 1000 - Now)).
 
-ensure_countdown_timer(State = #{timer := undefined}) ->
-    ensure_countdown_timer(State, timer:seconds(1));
-ensure_countdown_timer(State = #{timer := _TRef}) ->
-    State.
+%% Arm a fresh countdown timer for `Time` ms.
+%%
+%% `Time` is clamped to at least 1ms before arming: erlang:start_timer/3
+%% crashes the server on a negative timeout, and a zero timeout arms a timer
+%% that never delivers its message - both would leave the countdown dead.
+%% No new timer is armed while no buckets exist, so an idle limiter is not
+%% kept ticking by this call. A timer already running is not cancelled here:
+%% after the last bucket is deleted, the pending tick is still allowed to
+%% wind down (see ensure_countdown_timer/1).
+arm_countdown_timer(State = #{countdown := Countdown}, Time) ->
+    case maps:size(Countdown) of
+        0 -> State#{timer := undefined};
+        _ -> State#{timer := erlang:start_timer(max(1, Time), self(), countdown)}
+    end.
 
-ensure_countdown_timer(State = #{timer := undefined}, Time) when Time > 0 ->
-    TRef = erlang:start_timer(Time, self(), countdown),
-    State#{timer := TRef};
-ensure_countdown_timer(State = #{timer := _TRef}, _Time) ->
-    State.
+%% Guarantee the countdown invariant: while buckets exist, a live countdown
+%% timer is armed. The `timer` state field alone is not trusted - the reference
+%% is verified against erlang:read_timer/1, so a timer that has died (cancelled,
+%% or its reference replaced while a tick was still in flight) is re-armed.
+%% Every state transition that touches the countdown map - create, delete,
+%% and a stale countdown tick - ends here, so the invariant is re-established
+%% no matter how the previous timer was lost. (The countdown tick itself is
+%% the exception: it recomputes the schedule and arms the next timer directly
+%% via arm_countdown_timer/2.)
+%% Once the countdown is empty, a still-running timer is left alone and winds
+%% down on its next tick, so the limiter stops ticking at most one tick after
+%% the last bucket is deleted.
+ensure_countdown_timer(State = #{countdown := Countdown, timer := TRef}) ->
+    Running = is_reference(TRef) andalso is_integer(erlang:read_timer(TRef)),
+    case {Running, maps:size(Countdown)} of
+        {true, _} ->
+            State;
+        {false, 0} ->
+            State#{timer := undefined};
+        {false, _} ->
+            drain_countdown_ticks(),
+            arm_countdown_timer(State, timer:seconds(1))
+    end.
+
+%% Drain countdown tick messages that are already in the mailbox. With the
+%% timer dead, these can only be leaks from earlier timer generations; a leak
+%% that is processed in the window right after the re-armed timer has fired
+%% (e.g. a 1ms tick) but before its own message is handled would see the timer
+%% as dead again, arm yet another one, and drop the real tick - delaying every
+%% bucket's refill. Consuming the whole batch up front keeps a single re-arm
+%% from being followed by such a cascade.
+drain_countdown_ticks() ->
+    receive
+        {timeout, _Ref, countdown} -> drain_countdown_ticks()
+    after 0 ->
+        ok
+    end.

--- a/test/esockd_limiter_SUITE.erl
+++ b/test/esockd_limiter_SUITE.erl
@@ -326,6 +326,85 @@ t_delete_while_active(_) ->
         esockd_limiter:stop()
     end.
 
+%% While buckets exist a countdown timer must always be running, and it must
+%% come back if it dies: kill the timer behind the limiter's back, then touch
+%% the limiter with any config change and verify it is re-armed and buckets
+%% keep refilling on cadence.
+t_timer_self_heals_after_cancel(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(b, 100, 1),
+        timer:sleep(100),
+        #{timer := TRef} = sys:get_state(esockd_limiter),
+        ?assert(is_integer(erlang:read_timer(TRef))),
+        %% kill the timer behind the limiter's back: the state still holds
+        %% the now-dead reference
+        _ = erlang:cancel_timer(TRef),
+        #{timer := TRef} = sys:get_state(esockd_limiter),
+        ?assertEqual(false, erlang:read_timer(TRef)),
+        %% any config touch re-arms a live timer
+        ok = esockd_limiter:create(b2, 10, 1),
+        #{timer := TRef2} = sys:get_state(esockd_limiter),
+        ?assert(is_reference(TRef2)),
+        ?assert(is_integer(erlang:read_timer(TRef2))),
+        %% and the buckets still refill on cadence
+        drain(b, 100),
+        ok = expect_tokens(b, 100, 3000)
+    after
+        esockd_limiter:stop()
+    end.
+
+%% A countdown tick from a foreign (replaced/dead) timer reference must not
+%% disturb the live timer, and must leave the limiter armed.
+t_stale_countdown_tick_ignored_and_heals(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(b, 100, 1),
+        timer:sleep(100),
+        %% a stale tick: reference does not match the state
+        esockd_limiter ! {timeout, make_ref(), countdown},
+        timer:sleep(100),
+        #{timer := TRef2} = sys:get_state(esockd_limiter),
+        ?assert(is_integer(erlang:read_timer(TRef2))),
+        %% a stale tick against a dead timer must re-arm instead of stalling;
+        %% a burst of stale ticks (a leak from earlier timer generations) is
+        %% drained in one go, so it must not re-arm once per leaked message
+        _ = erlang:cancel_timer(TRef2),
+        [esockd_limiter ! {timeout, make_ref(), countdown} || _ <- lists:seq(1, 5)],
+        timer:sleep(100),
+        #{timer := TRef3} = sys:get_state(esockd_limiter),
+        ?assert(is_integer(erlang:read_timer(TRef3))),
+        %% refills still happen on cadence after the disturbances
+        drain(b, 100),
+        ok = expect_tokens(b, 100, 3000)
+    after
+        esockd_limiter:stop()
+    end.
+
+%% No buckets: no timer. An idle limiter must not tick forever.
+t_no_timer_without_buckets(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        %% fresh limiter: nothing armed
+        #{timer := undefined} = sys:get_state(esockd_limiter),
+        ok = esockd_limiter:create(b, 10, 1),
+        timer:sleep(100),
+        #{timer := TRef} = sys:get_state(esockd_limiter),
+        ?assert(is_reference(TRef)),
+        %% deleting the last bucket lets the last pending tick wind down
+        ok = esockd_limiter:delete(b),
+        timer:sleep(1500),
+        #{timer := undefined, countdown := Countdown} = sys:get_state(esockd_limiter),
+        ?assertEqual(0, map_size(Countdown)),
+        %% re-creating arms it again
+        ok = esockd_limiter:create(b, 10, 1),
+        timer:sleep(100),
+        #{timer := TRef2} = sys:get_state(esockd_limiter),
+        ?assert(is_integer(erlang:read_timer(TRef2)))
+    after
+        esockd_limiter:stop()
+    end.
+
 t_handle_call(_) ->
     {reply, ignore, state} = esockd_limiter:handle_call(req, '_From', state).
 

--- a/test/esockd_limiter_SUITE.erl
+++ b/test/esockd_limiter_SUITE.erl
@@ -164,6 +164,168 @@ t_concurrent_consume(_) ->
     ct:pal("~p~n", [ReceviedTokens2]),
     ?assertEqual(ConnRate, length(lists:usort(ReceviedTokens2))).
 
+%% Increase a bucket's interval via `update/3` must neither starve other buckets
+%% (regression: the shared countdown timer used to be stretched by ~Interval
+%% seconds, freezing a 1s conn-rate limiter) nor stall the limiter permanently
+%% (regression: an over-due tick computed a non-positive schedule, so no timer
+%% was armed again and no bucket ever refilled).
+t_update_larger_interval_no_starvation_no_stall(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(fast, 100, 1),
+        ok = esockd_limiter:create(slow, 1000, 1),
+        timer:sleep(300),
+        drain(fast, 100),
+        ok = update(slow, 1000, 10),
+        %% `fast` must keep refilling on its ~1s cadence, three cycles in a row.
+        ok = expect_tokens(fast, 100, 3000),
+        drain(fast, 100),
+        ok = expect_tokens(fast, 100, 3000),
+        drain(fast, 100),
+        ok = expect_tokens(fast, 100, 3000)
+    after
+        esockd_limiter:stop()
+    end.
+
+%% A long-interval bucket coexisting with a short-interval one (no update) must
+%% not slow the short-interval one down in steady state.
+t_steady_state_multiple_buckets_independent(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(fast, 100, 1),
+        ok = esockd_limiter:create(slow, 1000, 10),
+        timer:sleep(300),
+        drain(fast, 100),
+        ok = expect_tokens(fast, 100, 3000),
+        drain(fast, 100),
+        ok = expect_tokens(fast, 100, 3000),
+        %% `slow` keeps its config and stays usable.
+        #{tokens := 1000, interval := 10} = esockd_limiter:lookup(slow)
+    after
+        esockd_limiter:stop()
+    end.
+
+%% After `update` to a smaller interval the bucket must refill on the new,
+%% faster cadence.
+t_update_smaller_interval(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(b, 100, 10),
+        ok = update(b, 100, 1),
+        timer:sleep(300),
+        drain(b, 100),
+        ok = expect_tokens(b, 100, 3000)
+    after
+        esockd_limiter:stop()
+    end.
+
+%% A capacity-only update (same interval) resets the bucket and it keeps working.
+t_update_capacity_only_same_interval(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(b, 100, 1),
+        ok = update(b, 200, 1),
+        #{tokens := 200} = esockd_limiter:lookup(b),
+        {199, 0} = esockd_limiter:consume(b, 1),
+        timer:sleep(300),
+        drain(b, 199),
+        ok = expect_tokens(b, 200, 3000)
+    after
+        esockd_limiter:stop()
+    end.
+
+%% Over-consuming a burst many times the capacity must produce staggered pauses
+%% that stay bounded (borrowed from a finite number of future cycles), not a
+%% runaway pause value.
+t_burst_borrow_pause_bounded(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        Capacity = 100,
+        ok = esockd_limiter:create(b, Capacity, 1),
+        Pauses = [P || {_, P} <- [esockd_limiter:consume(b, 1)
+                                   || _ <- lists:seq(1, Capacity * 20)]],
+        MaxPause = lists:max(Pauses),
+        %% borrowed from at most ~20 future cycles, so < 21s + slack
+        ?assert(MaxPause < 21 * 1000 + 1000),
+        %% exhausted consumers are staggered, not all paused equally
+        ?assert(length(lists:usort(Pauses)) > 1),
+        %% no refill happens mid-burst, the bucket is left in debt
+        #{tokens := T} = esockd_limiter:lookup(b),
+        ?assert(T =< 0)
+    after
+        esockd_limiter:stop()
+    end.
+
+%% The acceptor passes `undefined` as the bucket name when no max_conn_rate is
+%% configured; consume must be a cheap no-op and never raise.
+t_consume_undefined_bucket(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        {1, 0} = esockd_limiter:consume(undefined, 1),
+        {1, 0} = esockd_limiter:consume(nonexistent_bucket, 1)
+    after
+        esockd_limiter:stop()
+    end.
+
+%% `get_all/1` must not crash when a bucket row is observed without its tokens
+%% row (a concurrent delete removes the bucket row first). Regression for the
+%% `ets:lookup_element` badarg in `tokens/1`.
+t_get_all_no_crash_with_orphan_bucket(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(real_bucket, 100, 1),
+        %% Simulate the mid-delete state: bucket row present, tokens row gone.
+        ets:insert(esockd_limiter, {{bucket, orphan}, 100, 1, 0}),
+        Buckets = esockd_limiter:get_all(),
+        ?assertMatch([#{name := orphan, tokens := 0}],
+                     [B || B = #{name := orphan} <- Buckets]),
+        ets:delete(esockd_limiter, {bucket, orphan})
+    after
+        esockd_limiter:stop()
+    end.
+
+%% create/update/delete churn must not leak state or break the countdown.
+t_create_update_delete_churn(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(c1, 10, 1),
+        ok = esockd_limiter:create(c2, 20, 2),
+        ok = update(c1, 30, 1),
+        #{tokens := 30} = esockd_limiter:lookup(c1),
+        ok = esockd_limiter:delete(c1),
+        ok = esockd_limiter:delete(c2),
+        timer:sleep(100),
+        undefined = esockd_limiter:lookup(c1),
+        undefined = esockd_limiter:lookup(c2),
+        %% re-create after delete: the countdown drives it again
+        ok = esockd_limiter:create(c1, 40, 1),
+        #{tokens := 40} = esockd_limiter:lookup(c1),
+        {39, 0} = esockd_limiter:consume(c1, 1),
+        drain(c1, 39),
+        ok = expect_tokens(c1, 40, 3000),
+        ok = esockd_limiter:delete(c1),
+        timer:sleep(100),
+        undefined = esockd_limiter:lookup(c1)
+    after
+        esockd_limiter:stop()
+    end.
+
+%% Deleting a bucket while consumers are paused on it must make subsequent
+%% consumes pause-free no-ops.
+t_delete_while_active(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(b, 1, 1),
+        {0, Pause} = esockd_limiter:consume(b, 1),
+        ?assert(Pause > 0),
+        ok = esockd_limiter:delete(b),
+        timer:sleep(100),
+        {1, 0} = esockd_limiter:consume(b, 1),
+        {1, 0} = esockd_limiter:consume(b, 1)
+    after
+        esockd_limiter:stop()
+    end.
+
 t_handle_call(_) ->
     {reply, ignore, state} = esockd_limiter:handle_call(req, '_From', state).
 
@@ -175,4 +337,41 @@ t_handle_info(_) ->
 
 t_code_change(_) ->
     {ok, state} = esockd_limiter:code_change('OldVsn', state, 'Extra').
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+%% Master removed the `esockd_limiter:update/3` API; emulate its (5.8.x)
+%% semantics for the regression tests above: refresh the bucket rows while
+%% keeping the countdown at min(Interval, OldCountdown), so the countdown can
+%% reach 1 well before LastTime + Interval * 1000.
+update(Name, Capacity, Interval) ->
+    true = ets:insert(esockd_limiter, {{tokens, Name}, Capacity}),
+    true = ets:insert(esockd_limiter,
+                      {{bucket, Name}, Capacity, Interval, erlang:system_time(millisecond)}),
+    sys:replace_state(
+        esockd_limiter,
+        fun(State = #{countdown := Countdown}) ->
+            Old = maps:get({bucket, Name}, Countdown, Interval),
+            State#{countdown := maps:put({bucket, Name}, erlang:min(Interval, Old), Countdown)}
+        end),
+    ok.
+
+drain(Name, Tokens) ->
+    lists:foreach(fun(_) -> esockd_limiter:consume(Name, 1) end, lists:seq(1, Tokens)).
+
+%% Wait until the bucket holds exactly `Tokens` tokens (a refill fills it to its
+%% capacity). `Timeout` is in milliseconds.
+expect_tokens(_Name, _Tokens, Timeout) when Timeout =< 0 ->
+    #{tokens := T} = esockd_limiter:lookup(_Name),
+    ct:fail("timeout waiting for ~p tokens, got ~p", [_Tokens, T]);
+expect_tokens(Name, Tokens, Timeout) ->
+    #{tokens := T} = esockd_limiter:lookup(Name),
+    case T of
+        Tokens -> ok;
+        _ ->
+            timer:sleep(50),
+            expect_tokens(Name, Tokens, Timeout - 50)
+    end.
 


### PR DESCRIPTION
Migrates #224 (`fix: clamp limiter countdown schedule to prevent starvation and stall`) and #225 (`fix: verify countdown timer liveness and re-arm it if dead`, including the review follow-up `drain stale countdown ticks before re-arming a dead timer`) from `bug_fixs/5.8.x` to `master`.

## What is changed

- `esockd_limiter:schedule_time/2` is clamped to `[1, 1000]` ms: countdown ticks stay ~1s so token refills keep the configured cadence, one bucket can no longer stretch the shared timer (starving e.g. a 1s conn-rate limiter), and an over-due tick always re-arms a timer instead of stalling the limiter permanently
- `tokens/1` tolerates a concurrently-deleted tokens row instead of crashing `get_all/1` / `lookup/1`
- countdown timer liveness is verified against `erlang:read_timer/1` and re-armed when dead (`arm_countdown_timer/2` / `ensure_countdown_timer/1` / `drain_countdown_ticks/0`); a stale countdown tick re-establishes the invariant instead of being logged as unexpected; an idle limiter (no buckets) no longer ticks forever
- `TEST` is defined in the test profile so the `-ifdef(TEST)` exports in `esockd_proxy_protocol` are present when running the test suite
- limiter test coverage: larger-interval starvation/stall regression, multi-bucket independence, smaller/same-interval updates, bounded burst-borrow pauses, undefined-bucket consume, orphan bucket row in `get_all`, create/update/delete churn, delete-while-active, timer self-heal after external cancel, stale tick (single + burst) handling, no-timer-without-buckets

## Adaptations vs. the 5.8.x originals

- master's `esockd_generic_limiter:consume/2` already short-circuits an undefined limiter, so the acceptor-side guards in `esockd_acceptor` / `esockd_dtls_acceptor` are not needed here
- master removed the `esockd_limiter:update/3` API; the regression tests emulate its (5.8.x) semantics via a local `update/3` helper that keeps the old low countdown value while refreshing the bucket rows

## Test result

`esockd_limiter_SUITE`: all 21 tests passed (OTP 24). The only other failure in the full CT run (`esockd_proxy_protocol_SUITE` `t_recv_ppv1`, socket group `eaddrinuse`) reproduces on a clean master as well and is unrelated.