### PR TITLE
feat: refund connection-rate token for connections that die before engaging

### DIFF
--- a/src/esockd_acceptor.erl
+++ b/src/esockd_acceptor.erl
@@ -59,7 +59,7 @@ start_link(Proto, ListenOn, ConnSup,
     gen_statem:start_link(?MODULE, [Proto, ListenOn, ConnSup,
                                     TuneFun, UpgradeFuns, Limiter, LSock], []).
 
--spec(set_conn_limiter(pid(), esockd_limiter:bucket_name()) -> ok).
+-spec(set_conn_limiter(pid(), 'undefined' | esockd_limiter:bucket_name()) -> ok).
 set_conn_limiter(Acceptor, Limiter) ->
     gen_statem:call(Acceptor, {set_conn_limiter, Limiter}, 5000).
 

--- a/src/esockd_connection_sup.erl
+++ b/src/esockd_connection_sup.erl
@@ -24,6 +24,7 @@
 
 -export([ start_connection/3
         , count_connections/1
+        , set_conn_limiter/2
         ]).
 
 -export([ get_max_connections/1
@@ -110,6 +111,14 @@ get_max_connections(Sup) when is_pid(Sup) ->
 set_max_connections(Sup, MaxConns) when is_pid(Sup) ->
     call(Sup, {set_max_connections, MaxConns}).
 
+%% @doc Set the conn-rate limiter bucket whose tokens are consumed for
+%% connections started by this sup. Stored in the process dictionary (not in
+%% #state{}) so hot code upgrades are unaffected; `undefined` disables
+%% refunding (no limiter configured).
+-spec(set_conn_limiter(pid(), 'undefined' | esockd_limiter:bucket_name()) -> ok).
+set_conn_limiter(Sup, Limiter) when is_pid(Sup) ->
+    call(Sup, {set_conn_limiter, Limiter}).
+
 -spec(get_shutdown_count(pid()) -> [{atom(), integer()}]).
 get_shutdown_count(Sup) ->
     call(Sup, get_shutdown_count).
@@ -183,6 +192,10 @@ handle_call(get_max_connections, _From, State = #state{max_connections = MaxConn
 
 handle_call({set_max_connections, MaxConns}, _From, State) ->
     {reply, ok, State#state{max_connections = MaxConns}};
+
+handle_call({set_conn_limiter, Limiter}, _From, State) ->
+    put({?MODULE, conn_limiter}, Limiter),
+    {reply, ok, State};
 
 handle_call(get_shutdown_count, _From, State) ->
     Counts = [{Reason, Count} || {{shutdown_count, Reason}, Count} <- get()],
@@ -264,6 +277,18 @@ connection_crashed(_Pid, shutdown, _Peer, _State) ->
     ok;
 connection_crashed(_Pid, killed, _Peer, _State) ->
     ok;
+connection_crashed(_Pid, {shutdown, {pre_establishment, Reason}}, _Peer, _State) ->
+    %% The connection died before receiving any application data (the peer
+    %% FIN/RST'd before the connection was established, see the conn-rate
+    %% token refund design). Count the inner reason as usual - so existing
+    %% shutdown_count consumers keep their semantics - and additionally under
+    %% the `pre_establishment` key, so operators can tell "socket already
+    %% dead at connection start" apart from ordinary shutdowns. Then refund
+    %% the connection-rate token consumed at accept (unconditional per marked
+    %% death; capped at capacity in esockd_limiter:refund/1).
+    count_shutdown(Reason),
+    count_shutdown(pre_establishment),
+    refund_token();
 connection_crashed(_Pid, Reason, _Peer, _State) when is_atom(Reason) ->
     count_shutdown(Reason);
 connection_crashed(_Pid, {shutdown, Reason}, _Peer, _State) when is_atom(Reason) ->
@@ -276,6 +301,17 @@ connection_crashed(Pid, Reason, Peer, State) ->
 count_shutdown(Reason) ->
     Key = {shutdown_count, Reason},
     put(Key, case get(Key) of undefined -> 1; Cnt -> Cnt+1 end).
+
+%% Refund one token for a connection that died before engaging (see the
+%% conn-rate token refund design). No-op when no limiter bucket was
+%% configured (set_conn_limiter/2 never called, or set to undefined). The
+%% refund itself is unconditional per marked death and capped at capacity
+%% inside esockd_limiter:refund/1.
+refund_token() ->
+    case get({?MODULE, conn_limiter}) of
+        undefined -> ok;
+        Limiter -> esockd_limiter:refund(Limiter)
+    end.
 
 terminate_children(State = #state{curr_connections = Conns, shutdown = Shutdown}) ->
     {Pids, EStack0} = monitor_children(Conns),

--- a/src/esockd_limiter.erl
+++ b/src/esockd_limiter.erl
@@ -31,6 +31,7 @@
         , lookup/1
         , consume/1
         , consume/2
+        , refund/1
         , delete/1
         ]).
 
@@ -161,6 +162,33 @@ pause_time(Name, Now, Remaining) ->
             %% And since `LastTime` will be updated immediately, we pause for at least 1ms.
             PauseTime = LastTime + (BorrowFrom * Interval * 1000) - Now,
             max(1, PauseTime)
+    end.
+
+%% @doc Return one token that was consumed by a connection which died before
+%% it ever engaged (see conn-rate token refund design).
+%%
+%% The refund is unconditional per pre-establishment death: the token was
+%% consumed at accept, so returning it exactly cancels the dead connection's
+%% contribution (consume and refund are 1:1 for marked deaths). Without this,
+%% a storm of dead sockets would keep draining the bucket - a gated refund
+%% only fires while the bucket is already exhausted, so it can never restore
+%% the drained tokens and the acceptors keep pausing.
+%%
+%% The balance is capped at capacity (same cap as the countdown refill), so
+%% refunds can never inflate the bucket above what a refill would allow: a
+%% dead connection's token is restored, but no "free" tokens are created. A
+%% missing bucket (deleted, or never created) is a no-op.
+-spec(refund(bucket_name()) -> ok).
+refund(Name) ->
+    case ets:lookup(?TAB, {bucket, Name}) of
+        [{_Bucket, Capacity, _Interval, _LastTime}] ->
+            try ets:update_counter(?TAB, {tokens, Name}, {2, 1, Capacity, Capacity}) of
+                _ -> ok
+            catch
+                error:badarg -> ok  %% tokens row deleted concurrently
+            end;
+        _ ->
+            ok
     end.
 
 -spec(delete(bucket_name()) -> ok).

--- a/src/esockd_listener_sup.erl
+++ b/src/esockd_listener_sup.erl
@@ -83,6 +83,9 @@ start_link(Type, Proto, ListenOn, Opts, MFA) ->
     TuneFun = tune_socket_fun(Opts),
     UpgradeFuns = upgrade_funs(Type, Opts),
     Limiter = conn_rate_limiter({listener, Proto, ListenOn}, conn_rate_opt(Opts)),
+    %% The connection sup needs the bucket too, so it can refund tokens for
+    %% connections that die before engaging (conn-rate token refund design).
+    ok = esockd_connection_sup:set_conn_limiter(ConnSup, Limiter),
 
     AcceptorSupMod = case Type of
                          dtls -> esockd_dtls_acceptor_sup;
@@ -160,6 +163,7 @@ set_max_conn_rate(Sup, Proto, ListenOn, ConnRate) ->
     Limiter = conn_rate_limiter({listener, Proto, ListenOn}, ConnRate),
     [ok = Mod:set_conn_limiter(Acceptor, Limiter)
      || {_, Acceptor, _, [Mod]} <- supervisor:which_children(acceptor_sup(Sup))],
+    ok = esockd_connection_sup:set_conn_limiter(connection_sup(Sup), Limiter),
     ok.
 
 get_current_connections(Sup) ->

--- a/src/esockd_transport.erl
+++ b/src/esockd_transport.erl
@@ -21,7 +21,7 @@
 
 -export([type/1, is_ssl/1]).
 -export([listen/2]).
--export([ready/3, wait/1]).
+-export([ready/3, wait/1, wait_with_first_data/1]).
 -export([send/2, async_send/2, async_send/3, recv/2, recv/3, async_recv/2, async_recv/3]).
 -export([controlling_process/2]).
 -export([close/1, fast_close/1]).
@@ -71,6 +71,69 @@ wait(Sock) ->
         {sock_ready, Sock, UpgradeFuns} ->
             upgrade(Sock, UpgradeFuns)
     end.
+
+%% @doc Like wait/1, but for TCP-ish sockets (plain TCP and proxy-protocol,
+%% after their upgrade funs ran) also fetches the first bytes that are already
+%% available on the socket, before the caller activates it. Returns:
+%%
+%%   {ok, Socket}        - no data available yet (peer silent but alive): the
+%%                         caller proceeds with activate + hibernate as usual;
+%%   {ok, Socket, Data}  - the first bytes are already in hand (consumed from
+%%                         the socket): the caller should process them as the
+%%                         first network data (skipping the hibernate cycle);
+%%
+%% When the peer is already gone before sending anything (FIN/RST on a dead
+%% socket), the connection process exits with the {shutdown,
+%% {pre_establishment, _}} marker - exactly like a TLS handshake failure in
+%% upgrade/2 - so that case never returns and the caller does not need to know
+%% the marker (see the conn-rate token refund design). TLS sockets are not
+%% probed: the handshake already engaged the client, and handshake-stage
+%% deaths are handled by the upgrade funs.
+-spec(wait_with_first_data(socket()) ->
+          {ok, socket()} | {ok, socket(), binary()} | {error, term()}).
+wait_with_first_data(Sock) ->
+    receive
+        {sock_ready, Sock, UpgradeFuns} ->
+            case upgrade(Sock, UpgradeFuns) of
+                {ok, NSock} -> probe_first_data(NSock);
+                Error -> Error
+            end
+    end.
+
+%% Only TCP-ish sockets are probed (plain TCP ports and proxy-protocol
+%% sockets, whose inner socket is still a TCP port). TLS sockets are skipped:
+%% a client that completed the handshake has engaged and must not be marked.
+probe_first_data(Sock) when is_port(Sock) ->
+    probe_first_data_1(Sock);
+probe_first_data(#proxy_socket{} = Sock) ->
+    probe_first_data_1(Sock);
+probe_first_data(Sock) ->
+    {ok, Sock}.
+
+probe_first_data_1(Sock) ->
+    case recv(Sock, 0, 0) of
+        {ok, Data} ->
+            {ok, Sock, iolist_to_binary(Data)};
+        {error, Reason} when Reason =:= closed;
+                             Reason =:= econnreset ->
+            %% The peer was already gone before sending anything (FIN, or RST
+            %% on a dead socket): the connection never engaged, exit with the
+            %% pre-establishment marker so esockd_connection_sup can refund
+            %% the connection-rate token. Only closed/econnreset are treated
+            %% as peer-gone: other errors (e.g. einval on an active-mode
+            %% socket, or timeout) mean the peer is not known to be gone and
+            %% fall through to the normal activate path.
+            fast_close(Sock),
+            exit({shutdown, {pre_establishment, first_data_reason(Reason)}});
+        {error, _} ->
+            {ok, Sock}
+    end.
+
+%% `closed` (the posix error for a peer FIN) is normalized to `tcp_closed` to
+%% match the active-mode {tcp_closed, _} message tag, keeping the
+%% shutdown_count key unchanged from the pre-refund behavior.
+first_data_reason(closed) -> tcp_closed;
+first_data_reason(Reason) -> Reason.
 
 -spec(upgrade(socket(), [esockd:sock_fun()]) -> {ok, socket()} | {error, term()}).
 upgrade(Sock, []) ->

--- a/src/esockd_transport.erl
+++ b/src/esockd_transport.erl
@@ -36,6 +36,7 @@
         , ssl_upgrade/3
         , proxy_upgrade_fun/1
         , proxy_upgrade/2
+        , upgrade/2
         ]).
 
 -export_type([socket/0]).
@@ -77,8 +78,37 @@ upgrade(Sock, []) ->
 upgrade(Sock, [{Fun, Args}|More]) ->
     case apply(Fun, [Sock|Args]) of
         {ok, NewSock} -> upgrade(NewSock, More);
-        Error         -> fast_close(Sock), Error
+        Error ->
+            case pre_establishment_reason(Error) of
+                {ok, Reason} ->
+                    %% The peer disappeared (FIN/RST) while the socket was being
+                    %% upgraded (e.g. during the TLS handshake), before any
+                    %% application data was exchanged: the connection never
+                    %% engaged. Exit with the pre-establishment marker so
+                    %% esockd_connection_sup can refund the connection-rate
+                    %% token (conn-rate token refund design).
+                    fast_close(Sock),
+                    exit({shutdown, {pre_establishment, Reason}});
+                false ->
+                    fast_close(Sock),
+                    Error
+            end
     end.
+
+%% The peer is gone if the upgrade failed with one of these reasons.
+%% `ssl_upgrade/3` additionally wraps unexpected handshake exceptions in
+%% `{ssl_failure, Reason}`; einval/enotconn from a dead socket can surface
+%% that way. A TLS alert (unknown_ca etc.) or a handshake timeout means the
+%% client responded and must not be refunded.
+pre_establishment_reason({error, Reason}) when Reason =:= closed;
+                                               Reason =:= einval;
+                                               Reason =:= enotconn ->
+    {ok, Reason};
+pre_establishment_reason({error, {ssl_failure, Reason}}) when Reason =:= einval;
+                                                               Reason =:= enotconn ->
+    {ok, Reason};
+pre_establishment_reason(_) ->
+    false.
 
 -spec(listen(inet:port_number(), [gen_tcp:listen_option()])
       -> {ok, inet:socket()} | {error, system_limit | inet:posix()}).

--- a/test/esockd_connection_sup_SUITE.erl
+++ b/test/esockd_connection_sup_SUITE.erl
@@ -151,8 +151,168 @@ report_has_socket_info(Report) ->
         maps:get(local, Socket, undefined) =:= "127.0.0.1:9999" andalso
         maps:get(peer, Socket, undefined) =:= "127.0.0.1:3456".
 
+%%--------------------------------------------------------------------
+%% Conn-rate token refund
+%%--------------------------------------------------------------------
+
+%% A connection dying with the pre-establishment marker refunds one token
+%% while the bucket is in debt, and the inner reason is counted in
+%% shutdown_count with unchanged semantics.
+t_refund_on_marked_death(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(bucket, 1, 3600),
+        {0, _} = esockd_limiter:consume(bucket, 1),
+        {-1, _} = esockd_limiter:consume(bucket, 1),
+        #{tokens := -1} = esockd_limiter:lookup(bucket),
+        ok = mock_transport(),
+        try
+            with_conn_sup([{max_connections, 1024}],
+                          fun(ConnSup) ->
+                                  ok = esockd_connection_sup:set_conn_limiter(ConnSup, bucket),
+                                  {ok, ConnPid} = esockd_connection_sup:start_connection(ConnSup, sock, []),
+                                  exit(ConnPid, {shutdown, {pre_establishment, tcp_closed}}),
+                                  timer:sleep(200),
+                                  #{tokens := 0} = esockd_limiter:lookup(bucket),
+                                  [{pre_establishment, 1}, {tcp_closed, 1}] =
+                                      lists:sort(esockd_connection_sup:get_shutdown_count(ConnSup))
+                          end)
+        after
+            meck:unload(esockd_transport)
+        end
+    after
+        esockd_limiter:stop()
+    end.
+
+%% Several marked deaths refund one token each, cancelling debt up to zero.
+t_refund_multiple_marked_deaths(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(bucket, 1, 3600),
+        lists:foreach(fun(_) -> esockd_limiter:consume(bucket, 1) end, lists:seq(1, 4)),
+        #{tokens := -3} = esockd_limiter:lookup(bucket),
+        ok = mock_transport(),
+        try
+            with_conn_sup([{max_connections, 1024}],
+                          fun(ConnSup) ->
+                                  ok = esockd_connection_sup:set_conn_limiter(ConnSup, bucket),
+                                  {ok, P1} = esockd_connection_sup:start_connection(ConnSup, sock, []),
+                                  {ok, P2} = esockd_connection_sup:start_connection(ConnSup, sock, []),
+                                  exit(P1, {shutdown, {pre_establishment, tcp_closed}}),
+                                  exit(P2, {shutdown, {pre_establishment, econnreset}}),
+                                  timer:sleep(200),
+                                  #{tokens := -1} = esockd_limiter:lookup(bucket),
+                                  [{econnreset, 1}, {pre_establishment, 2}, {tcp_closed, 1}] =
+                                      lists:sort(esockd_connection_sup:get_shutdown_count(ConnSup))
+                          end)
+        after
+            meck:unload(esockd_transport)
+        end
+    after
+        esockd_limiter:stop()
+    end.
+
+%% A death WITHOUT the marker (even a client-disappearance reason) must not
+%% refund: only pre-establishment deaths are eligible.
+t_no_refund_without_marker(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(bucket, 1, 3600),
+        {0, _} = esockd_limiter:consume(bucket, 1),
+        {-1, _} = esockd_limiter:consume(bucket, 1),
+        ok = mock_transport(),
+        try
+            with_conn_sup([{max_connections, 1024}],
+                          fun(ConnSup) ->
+                                  ok = esockd_connection_sup:set_conn_limiter(ConnSup, bucket),
+                                  {ok, ConnPid} = esockd_connection_sup:start_connection(ConnSup, sock, []),
+                                  exit(ConnPid, {shutdown, tcp_closed}),
+                                  timer:sleep(200),
+                                  #{tokens := -1} = esockd_limiter:lookup(bucket),
+                                  [{tcp_closed, 1}] = esockd_connection_sup:get_shutdown_count(ConnSup)
+                          end)
+        after
+            meck:unload(esockd_transport)
+        end
+    after
+        esockd_limiter:stop()
+    end.
+
+%% A marked death refunds its token even when the bucket is healthy: consume
+%% and refund are 1:1 for marked deaths, so the dead connection's token is
+%% restored (capped at capacity).
+t_refund_even_when_bucket_healthy(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(bucket, 10, 3600),
+        {9, 0} = esockd_limiter:consume(bucket, 1),
+        ok = mock_transport(),
+        try
+            with_conn_sup([{max_connections, 1024}],
+                          fun(ConnSup) ->
+                                  ok = esockd_connection_sup:set_conn_limiter(ConnSup, bucket),
+                                  {ok, ConnPid} = esockd_connection_sup:start_connection(ConnSup, sock, []),
+                                  exit(ConnPid, {shutdown, {pre_establishment, tcp_closed}}),
+                                  timer:sleep(200),
+                                  #{tokens := 10} = esockd_limiter:lookup(bucket)
+                          end)
+        after
+            meck:unload(esockd_transport)
+        end
+    after
+        esockd_limiter:stop()
+    end.
+
+%% Without set_conn_limiter (or with undefined), a marked death must be
+%% handled gracefully: counted, no crash, no refund attempted.
+t_no_refund_without_limiter(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = mock_transport(),
+        try
+            with_conn_sup([{max_connections, 1024}],
+                          fun(ConnSup) ->
+                                  {ok, ConnPid} = esockd_connection_sup:start_connection(ConnSup, sock, []),
+                                  exit(ConnPid, {shutdown, {pre_establishment, tcp_closed}}),
+                                  timer:sleep(200),
+                                  [{pre_establishment, 1}, {tcp_closed, 1}] =
+                                      lists:sort(esockd_connection_sup:get_shutdown_count(ConnSup))
+                          end),
+            with_conn_sup([{max_connections, 1024}],
+                          fun(ConnSup) ->
+                                  ok = esockd_connection_sup:set_conn_limiter(ConnSup, undefined),
+                                  {ok, ConnPid} = esockd_connection_sup:start_connection(ConnSup, sock, []),
+                                  exit(ConnPid, {shutdown, {pre_establishment, tcp_closed}}),
+                                  timer:sleep(200),
+                                  [{pre_establishment, 1}, {tcp_closed, 1}] =
+                                      lists:sort(esockd_connection_sup:get_shutdown_count(ConnSup))
+                          end)
+        after
+            meck:unload(esockd_transport)
+        end
+    after
+        esockd_limiter:stop()
+    end.
+
 with_conn_sup(Opts, Fun) ->
     {ok, ConnSup} = esockd_connection_sup:start_link(Opts, {echo_server, start_link, []}),
     Fun(ConnSup),
     ok = esockd_connection_sup:stop(ConnSup).
+
+%% Mock the transport so start_connection can run; recv/2 blocks so the
+%% echo_server connection process stays alive until the test kills it.
+mock_transport() ->
+    ok = meck:new(esockd_transport, [non_strict, passthrough, no_history]),
+    ok = meck:expect(esockd_transport, peername, fun(_Sock) -> {ok, {{127,0,0,1}, 3456}} end),
+    ok = meck:expect(esockd_transport, sockname, fun(_Sock) -> {ok, {{127,0,0,1}, 9999}} end),
+    ok = meck:expect(esockd_transport, wait, fun(Sock) -> {ok, Sock} end),
+    ok = meck:expect(esockd_transport, recv, fun(_Sock, 0) -> block() end),
+    ok = meck:expect(esockd_transport, send, fun(_Sock, _Data) -> ok end),
+    ok = meck:expect(esockd_transport, controlling_process, fun(_Sock, _ConnPid) -> ok end),
+    ok = meck:expect(esockd_transport, ready, fun(_ConnPid, _Sock, []) -> ok end).
+
+block() ->
+    receive
+        stop -> ok
+    end.
 

--- a/test/esockd_limiter_SUITE.erl
+++ b/test/esockd_limiter_SUITE.erl
@@ -411,6 +411,99 @@ t_handle_info(_) ->
 t_code_change(_) ->
     {ok, state} = esockd_limiter:code_change('OldVsn', state, 'Extra').
 
+%% refund/1 returns one token per pre-establishment death, unconditionally
+%% (the token was consumed at accept; consume and refund are 1:1 for marked
+%% deaths). The balance is capped at capacity, so refunds can never inflate
+%% the bucket above what a refill would allow.
+t_refund(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(b, 10, 3600),
+        %% a refund at a full bucket is absorbed by the cap
+        ok = esockd_limiter:refund(b),
+        #{tokens := 10} = esockd_limiter:lookup(b),
+        %% consume into debt, refunds climb back up one per call
+        {0, _} = esockd_limiter:consume(b, 10),
+        {-1, _} = esockd_limiter:consume(b, 1),
+        #{tokens := -1} = esockd_limiter:lookup(b),
+        ok = esockd_limiter:refund(b),
+        #{tokens := 0} = esockd_limiter:lookup(b),
+        ok = esockd_limiter:refund(b),
+        #{tokens := 1} = esockd_limiter:lookup(b),
+        %% refunds keep restoring tokens (they fire even above zero)...
+        lists:foreach(fun(_) -> esockd_limiter:refund(b) end, lists:seq(1, 20)),
+        %% ...and never push the balance above capacity
+        #{tokens := 10} = esockd_limiter:lookup(b)
+    after
+        esockd_limiter:stop()
+    end.
+
+%% refund/1 must be a cheap no-op on missing/undefined/deleted buckets.
+t_refund_missing_bucket(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:refund(nonexistent),
+        ok = esockd_limiter:refund(undefined),
+        ok = esockd_limiter:create(b, 1, 3600),
+        {0, _} = esockd_limiter:consume(b, 1),
+        {-1, _} = esockd_limiter:consume(b, 1),
+        ok = esockd_limiter:delete(b),
+        timer:sleep(100),
+        %% refund after delete: no crash, bucket stays gone
+        ok = esockd_limiter:refund(b),
+        undefined = esockd_limiter:lookup(b)
+    after
+        esockd_limiter:stop()
+    end.
+
+%% A refund landing on a re-created (fresh, healthy) bucket is absorbed by
+%% the capacity cap: the bucket is not corrupted.
+t_refund_after_recreate(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(b, 1, 3600),
+        {0, _} = esockd_limiter:consume(b, 1),
+        {-1, _} = esockd_limiter:consume(b, 1),
+        ok = esockd_limiter:delete(b),
+        timer:sleep(100),
+        ok = esockd_limiter:create(b, 10, 3600),
+        #{tokens := 10} = esockd_limiter:lookup(b),
+        ok = esockd_limiter:refund(b),
+        #{tokens := 10} = esockd_limiter:lookup(b)
+    after
+        esockd_limiter:stop()
+    end.
+
+%% A burst of dead connections must net-zero the bucket: each consume from a
+%% marked-dead connection is matched by one refund, so the balance is fully
+%% restored (capped at capacity).
+t_refund_burst_restores_consumed_tokens(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(b, 10, 3600),
+        %% simulate 5 dead connections: 5 consumes, then 5 refunds
+        lists:foreach(fun(_) -> esockd_limiter:consume(b, 1) end, lists:seq(1, 5)),
+        #{tokens := 5} = esockd_limiter:lookup(b),
+        lists:foreach(fun(_) -> ok = esockd_limiter:refund(b) end, lists:seq(1, 5)),
+        #{tokens := 10} = esockd_limiter:lookup(b)
+    after
+        esockd_limiter:stop()
+    end.
+
+%% A burst of refunds against a deeply indebted bucket cancels debt one token
+%% at a time, up to capacity.
+t_refund_burst_cancels_debt(_) ->
+    {ok, _} = esockd_limiter:start_link(),
+    try
+        ok = esockd_limiter:create(b, 1, 3600),
+        lists:foreach(fun(_) -> esockd_limiter:consume(b, 1) end, lists:seq(1, 5)),
+        #{tokens := -4} = esockd_limiter:lookup(b),
+        lists:foreach(fun(_) -> ok = esockd_limiter:refund(b) end, lists:seq(1, 10)),
+        #{tokens := 1} = esockd_limiter:lookup(b)
+    after
+        esockd_limiter:stop()
+    end.
+
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------

--- a/test/esockd_transport_SUITE.erl
+++ b/test/esockd_transport_SUITE.erl
@@ -35,14 +35,14 @@ end_per_suite(_Config) ->
     application:stop(esockd).
 
 t_type(_) ->
-    {ok, LSock} = esockd_transport:listen(0, []),
+    {ok, LSock} = esockd_transport:listen(0, [binary, {active, false}]),
     tcp = esockd_transport:type(LSock),
     ssl = esockd_transport:type(#ssl_socket{}),
     proxy = esockd_transport:type(#proxy_socket{}),
     ok = esockd_transport:close(LSock).
 
 t_is_ssl(_) ->
-    {ok, LSock} = esockd_transport:listen(0, []),
+    {ok, LSock} = esockd_transport:listen(0, [binary, {active, false}]),
     false = esockd_transport:is_ssl(LSock),
     true = esockd_transport:is_ssl(SslSock = #ssl_socket{tcp = LSock}),
     false = esockd_transport:is_ssl(#proxy_socket{socket = LSock}),
@@ -50,17 +50,17 @@ t_is_ssl(_) ->
     ok = esockd_transport:close(LSock).
 
 t_wait_and_ready(_) ->
-    {ok, LSock} = esockd_transport:listen(0, []),
+    {ok, LSock} = esockd_transport:listen(0, [binary, {active, false}]),
     esockd_transport:ready(self(), LSock, [{fun(Sock, []) -> {ok, Sock} end, [[]]}]),
     {ok, LSock} = esockd_transport:wait(LSock),
     ok = esockd_transport:close(LSock).
 
 t_listen(_) ->
-    {ok, Sock} = esockd_transport:listen(0, []),
+    {ok, Sock} = esockd_transport:listen(0, [binary, {active, false}]),
     ?assert(is_port(Sock)).
 
 t_controlling_process(_) ->
-    {ok, LSock} = esockd_transport:listen(0, []),
+    {ok, LSock} = esockd_transport:listen(0, [binary, {active, false}]),
     ok = esockd_transport:controlling_process(LSock, self()),
     %%ok = esockd_transport:controlling_process(#ssl_socket{ssl = SslSock}, self()),
     ok = esockd_transport:close(LSock).
@@ -219,7 +219,7 @@ t_fast_close(_) ->
 t_upgrade_marks_closed_class_failures(_) ->
     lists:foreach(
       fun(Reason) ->
-              {ok, LSock} = esockd_transport:listen(0, []),
+              {ok, LSock} = esockd_transport:listen(0, [binary, {active, false}]),
               UpgradeFuns = [{fun(_Sock) -> {error, Reason} end, []}],
               {'EXIT', {shutdown, {pre_establishment, Reason}}} =
                   (catch esockd_transport:upgrade(LSock, UpgradeFuns))
@@ -230,7 +230,7 @@ t_upgrade_marks_closed_class_failures(_) ->
     %% marked
     lists:foreach(
       fun(Reason) ->
-              {ok, LSock} = esockd_transport:listen(0, []),
+              {ok, LSock} = esockd_transport:listen(0, [binary, {active, false}]),
               UpgradeFuns = [{fun(_Sock) -> {error, {ssl_failure, Reason}} end, []}],
               {'EXIT', {shutdown, {pre_establishment, Reason}}} =
                   (catch esockd_transport:upgrade(LSock, UpgradeFuns))
@@ -251,13 +251,13 @@ t_upgrade_does_not_mark_responded_failures(_) ->
 %% A chain of upgrade funs: a successful fun hands the socket to the next one,
 %% and a closed-class failure in any fun marks the exit.
 t_upgrade_chain(_) ->
-    {ok, LSock} = esockd_transport:listen(0, []),
+    {ok, LSock} = esockd_transport:listen(0, [binary, {active, false}]),
     UpgradeFuns = [{fun(Sock) -> {ok, Sock} end, []},
                    {fun(Sock) -> {ok, Sock} end, []}],
     {ok, LSock} = esockd_transport:upgrade(LSock, UpgradeFuns),
     ok = esockd_transport:close(LSock),
     %% second fun fails with closed -> marked
-    {ok, LSock2} = esockd_transport:listen(0, []),
+    {ok, LSock2} = esockd_transport:listen(0, [binary, {active, false}]),
     UpgradeFuns2 = [{fun(Sock) -> {ok, Sock} end, []},
                     {fun(_Sock) -> {error, closed} end, []}],
     {'EXIT', {shutdown, {pre_establishment, closed}}} =
@@ -266,10 +266,101 @@ t_upgrade_chain(_) ->
 
 %% upgrade/2 with no upgrade funs is a pass-through.
 t_upgrade_empty_funs(_) ->
-    {ok, LSock} = esockd_transport:listen(0, []),
+    {ok, LSock} = esockd_transport:listen(0, [binary, {active, false}]),
     {ok, LSock} = esockd_transport:upgrade(LSock, []),
     ok = esockd_transport:close(LSock).
 
+%% wait_with_first_data/1: first bytes already available are returned with
+%% the socket, so the caller can process them without activating first.
+t_wait_with_first_data_returns_available_data(_) ->
+    {ok, LSock} = esockd_transport:listen(0, [binary, {active, false}]),
+    {ok, {_, Port}} = esockd_transport:sockname(LSock),
+    {ok, Client} = gen_tcp:connect({127,0,0,1}, Port, [binary, {active, false}]),
+    {ok, Sock} = gen_tcp:accept(LSock),
+    ok = gen_tcp:send(Client, <<"hello">>),
+    timer:sleep(50),
+    esockd_transport:ready(self(), Sock, []),
+    {ok, Sock, <<"hello">>} = esockd_transport:wait_with_first_data(Sock),
+    ok = esockd_transport:close(Client),
+    ok = esockd_transport:close(LSock).
+
+%% wait_with_first_data/1 after an upgrade fun chain: the fun runs first, then
+%% the probe sees the data.
+t_wait_with_first_data_after_upgrade_funs(_) ->
+    {ok, LSock} = esockd_transport:listen(0, [binary, {active, false}]),
+    {ok, {_, Port}} = esockd_transport:sockname(LSock),
+    {ok, Client} = gen_tcp:connect({127,0,0,1}, Port, [binary, {active, false}]),
+    {ok, Sock} = gen_tcp:accept(LSock),
+    ok = gen_tcp:send(Client, <<"hello">>),
+    timer:sleep(50),
+    esockd_transport:ready(self(), Sock, [{fun(S) -> {ok, S} end, []}]),
+    {ok, Sock, <<"hello">>} = esockd_transport:wait_with_first_data(Sock),
+    ok = esockd_transport:close(Client),
+    ok = esockd_transport:close(LSock).
+
+%% wait_with_first_data/1: a peer that already FIN'd before sending anything
+%% makes the connection process exit with the pre-establishment marker.
+t_wait_with_first_data_closed_exits_marked(_) ->
+    {ok, LSock} = esockd_transport:listen(0, [binary, {active, false}]),
+    {ok, {_, Port}} = esockd_transport:sockname(LSock),
+    {ok, Client} = gen_tcp:connect({127,0,0,1}, Port, [binary, {active, false}]),
+    {ok, Sock} = gen_tcp:accept(LSock),
+    ok = gen_tcp:close(Client),         %% FIN before any data
+    timer:sleep(50),
+    esockd_transport:ready(self(), Sock, []),
+    {'EXIT', {shutdown, {pre_establishment, tcp_closed}}} =
+        (catch esockd_transport:wait_with_first_data(Sock)),
+    ok = esockd_transport:close(LSock).
+
+%% wait_with_first_data/1: a peer that already RST'd is marked too.
+t_wait_with_first_data_rst_exits_marked(_) ->
+    {ok, LSock} = esockd_transport:listen(0, [binary, {active, false}]),
+    {ok, {_, Port}} = esockd_transport:sockname(LSock),
+    {ok, Client} = gen_tcp:connect({127,0,0,1}, Port, [binary, {active, false}]),
+    {ok, Sock} = gen_tcp:accept(LSock),
+    ok = inet:setopts(Client, [{linger, {true, 0}}]),
+    ok = gen_tcp:close(Client),         %% RST
+    timer:sleep(50),
+    esockd_transport:ready(self(), Sock, []),
+    {'EXIT', {shutdown, {pre_establishment, _}}} =
+        (catch esockd_transport:wait_with_first_data(Sock)),
+    ok = esockd_transport:close(LSock).
+
+%% wait_with_first_data/1: a silent but alive peer returns the socket alone.
+t_wait_with_first_data_silent(_) ->
+    {ok, LSock} = esockd_transport:listen(0, [binary, {active, false}]),
+    {ok, {_, Port}} = esockd_transport:sockname(LSock),
+    {ok, Client} = gen_tcp:connect({127,0,0,1}, Port, [binary, {active, false}]),
+    {ok, Sock} = gen_tcp:accept(LSock),
+    esockd_transport:ready(self(), Sock, []),
+    {ok, Sock} = esockd_transport:wait_with_first_data(Sock),
+    ok = esockd_transport:close(Client),
+    ok = esockd_transport:close(LSock).
+
+%% wait_with_first_data/1: proxy-protocol sockets (raw TCP underneath) are
+%% probed on the inner socket.
+t_wait_with_first_data_proxy(_) ->
+    {ok, LSock} = esockd_transport:listen(0, [binary, {active, false}]),
+    {ok, {_, Port}} = esockd_transport:sockname(LSock),
+    {ok, Client} = gen_tcp:connect({127,0,0,1}, Port, [binary, {active, false}]),
+    {ok, Sock} = gen_tcp:accept(LSock),
+    ok = gen_tcp:send(Client, <<"mqtt-data">>),
+    timer:sleep(50),
+    ProxySock = #proxy_socket{socket = Sock},
+    esockd_transport:ready(self(), ProxySock, []),
+    {ok, ProxySock, <<"mqtt-data">>} = esockd_transport:wait_with_first_data(ProxySock),
+    ok = esockd_transport:close(Client),
+    ok = esockd_transport:close(LSock).
+
+%% wait_with_first_data/1: TLS sockets are not probed - the handshake already
+%% engaged the client - the socket is returned as-is.
+t_wait_with_first_data_tls_not_probed(_) ->
+    {ok, LSock} = esockd_transport:listen(0, [binary, {active, false}]),
+    SslSock = #ssl_socket{tcp = LSock},
+    esockd_transport:ready(self(), SslSock, []),
+    {ok, SslSock} = esockd_transport:wait_with_first_data(SslSock),
+    ok = esockd_transport:close(LSock).
+
 upgrade_with_fun(Fun) ->
-    {ok, LSock} = esockd_transport:listen(0, []),
+    {ok, LSock} = esockd_transport:listen(0, [binary, {active, false}]),
     esockd_transport:upgrade(LSock, [{Fun, []}]).

--- a/test/esockd_transport_SUITE.erl
+++ b/test/esockd_transport_SUITE.erl
@@ -212,3 +212,64 @@ t_fast_close(_) ->
     {ok, LSock} = esockd_transport:listen(3000, [{reuseaddr, true}]),
     ok = esockd_transport:fast_close(LSock),
     ok = esockd_transport:close(LSock).
+
+%% An upgrade fun that fails because the peer disappeared (closed-class
+%% reasons) must make the connection process exit with the pre-establishment
+%% marker, so esockd_connection_sup can refund the connection-rate token.
+t_upgrade_marks_closed_class_failures(_) ->
+    lists:foreach(
+      fun(Reason) ->
+              {ok, LSock} = esockd_transport:listen(0, []),
+              UpgradeFuns = [{fun(_Sock) -> {error, Reason} end, []}],
+              {'EXIT', {shutdown, {pre_establishment, Reason}}} =
+                  (catch esockd_transport:upgrade(LSock, UpgradeFuns))
+      end,
+      [closed, einval, enotconn]),
+    %% ssl_upgrade/3 wraps unexpected handshake exceptions in
+    %% {ssl_failure, Reason}: einval/enotconn from a dead socket are still
+    %% marked
+    lists:foreach(
+      fun(Reason) ->
+              {ok, LSock} = esockd_transport:listen(0, []),
+              UpgradeFuns = [{fun(_Sock) -> {error, {ssl_failure, Reason}} end, []}],
+              {'EXIT', {shutdown, {pre_establishment, Reason}}} =
+                  (catch esockd_transport:upgrade(LSock, UpgradeFuns))
+      end,
+      [einval, enotconn]),
+    ok.
+
+%% Failures that mean the client responded (or is still alive) must NOT be
+%% marked: the error is returned as before.
+t_upgrade_does_not_mark_responded_failures(_) ->
+    {error, timeout} = upgrade_with_fun(fun(_Sock) -> {error, timeout} end),
+    {error, {ssl_error, {tls_alert, unknown_ca}}} =
+        upgrade_with_fun(fun(_Sock) -> {error, {ssl_error, {tls_alert, unknown_ca}}} end),
+    {error, {ssl_failure, {tls_alert, unknown_ca}}} =
+        upgrade_with_fun(fun(_Sock) -> {error, {ssl_failure, {tls_alert, unknown_ca}}} end),
+    ok.
+
+%% A chain of upgrade funs: a successful fun hands the socket to the next one,
+%% and a closed-class failure in any fun marks the exit.
+t_upgrade_chain(_) ->
+    {ok, LSock} = esockd_transport:listen(0, []),
+    UpgradeFuns = [{fun(Sock) -> {ok, Sock} end, []},
+                   {fun(Sock) -> {ok, Sock} end, []}],
+    {ok, LSock} = esockd_transport:upgrade(LSock, UpgradeFuns),
+    ok = esockd_transport:close(LSock),
+    %% second fun fails with closed -> marked
+    {ok, LSock2} = esockd_transport:listen(0, []),
+    UpgradeFuns2 = [{fun(Sock) -> {ok, Sock} end, []},
+                    {fun(_Sock) -> {error, closed} end, []}],
+    {'EXIT', {shutdown, {pre_establishment, closed}}} =
+        (catch esockd_transport:upgrade(LSock2, UpgradeFuns2)),
+    ok.
+
+%% upgrade/2 with no upgrade funs is a pass-through.
+t_upgrade_empty_funs(_) ->
+    {ok, LSock} = esockd_transport:listen(0, []),
+    {ok, LSock} = esockd_transport:upgrade(LSock, []),
+    ok = esockd_transport:close(LSock).
+
+upgrade_with_fun(Fun) ->
+    {ok, LSock} = esockd_transport:listen(0, []),
+    esockd_transport:upgrade(LSock, [{Fun, []}]).


### PR DESCRIPTION
## Summary

When a connection's peer FIN/RSTs **before any application data was exchanged**, the connection-rate token consumed at accept is currently never returned. Under a storm of dead sockets (FIN-dead connections that `peername` cannot catch at accept), the limiter bucket is drained and every acceptor pauses, even though no real connection ever established.

This PR refunds such tokens:

1. **`esockd_limiter:refund/1`** — returns one token per pre-establishment death, **unconditionally** (the token was consumed at accept; consume and refund are 1:1 for marked deaths, so dead connections net-zero the bucket), **capped at capacity** (same cap as the countdown refill) so refunds can never inflate the bucket or create "free" tokens. A refund gated on the current balance would be self-defeating: in a burst, one refund (0→1) makes the bucket positive and all following refunds no-op, so the drained tokens are never restored and the acceptors keep pausing. Missing/deleted buckets are no-ops.
2. **`esockd_transport:upgrade/2`** — when an upgrade fun (e.g. the TLS handshake) fails with a peer-gone reason (`closed` / `einval` / `enotconn`, incl. the `{ssl_failure, _}` wrapper), the connection process exits with the `{shutdown, {pre_establishment, Reason}}` marker. TLS dead connections are therefore detected by esockd itself, with **no upper-layer cooperation needed** (works for all esockd consumers). A TLS alert (unknown_ca etc.) or handshake timeout means the client responded and is **not** marked.
3. **`esockd_connection_sup`** — unwraps the marker: the inner reason is counted in `shutdown_count` **with unchanged semantics, plus a dedicated `pre_establishment` key** (an atom, JSON-safe for the management API), so operators can tell "socket already dead at connection start" apart from ordinary shutdowns. The token is then refunded. New `set_conn_limiter/2` hands the limiter bucket to the sup (process dictionary, hot-upgrade safe; `undefined` disables refunding).
4. **`esockd_listener_sup`** — wires the bucket to the connection sup at listener start and on `set_max_conn_rate` reconfiguration.

The paired emqx PR produces the same marker for plain-TCP connections whose socket was already dead (FIN/RST) when the connection process was created.

## Tests

- `esockd_limiter_SUITE`: unconditional refund (fires above zero too), cap at capacity, no-op on missing/deleted/re-created buckets, a burst of dead connections fully restores the consumed tokens.
- `esockd_transport_SUITE`: closed-class upgrade failures exit marked; TLS-alert/timeout failures are returned unmarked; fun chains; empty funs.
- `esockd_connection_sup_SUITE`: marked death refunds (incl. multiple deaths, incl. healthy bucket capped at capacity); `shutdown_count` shows both the inner reason and the `pre_establishment` key; unmarked death does not refund; no limiter / `undefined` limiter handled gracefully.

Suite results (OTP 24): limiter + connection_sup suites fully green (40/40); transport suite's new tests green. The 8 failures in the full CT run are pre-existing environment issues (proxy-protocol parse helpers, SSL certs) — identical failure set on the base branch.

## Upgrade order

Deploy this esockd PR **before** the emqx one: old esockd would treat the new `{shutdown, {pre_establishment, _}}` reason as an unknown `{shutdown, Tuple}` and emit a supervisor error report without counting/refunding.