### PR TITLE
feat(socket): rely on acceptors to notify listen socket closed

### DIFF
--- a/src/esockd_acceptor_fsm.erl
+++ b/src/esockd_acceptor_fsm.erl
@@ -60,6 +60,7 @@
     modctx :: {module(), _Ctx},
     upgrade_funs :: [esockd:sock_fun()],
     conn_limiter :: undefined | esockd_generic_limiter:limiter(),
+    listener :: pid(),
     conn_sup :: pid()
                 %% NOTE: Only for tests
                 | {function(), [term()]}
@@ -91,12 +92,14 @@ callback_mode() ->
 
 init([ListenerRef, ConnSup, {Mod, Opts}, UpgradeFuns, Limiter, LSock]) ->
     _ = erlang:process_flag(trap_exit, true),
+    {_Mod, Listener} = esockd_server:get_listener_prop(ListenerRef, listener),
     Ctx = Mod:init(LSock, Opts),
     D = #d{
         listener_ref = ListenerRef,
         modctx = {Mod, Ctx},
         upgrade_funs = UpgradeFuns,
         conn_limiter = Limiter,
+        listener = Listener,
         conn_sup = ConnSup
     },
     {ok, waiting, D, {next_event, internal, accept}}.
@@ -112,7 +115,7 @@ handle_event(internal, accept, State, D) when State =:= waiting orelse
             inc_stats(D, econnaborted),
             {keep_state, D, {next_event, internal, accept}};
         {error, closed} ->
-            {stop, normal, D};
+            listener_socket_closed(D);
         {error, Reason} ->
             {stop, Reason, D}
     end;
@@ -236,7 +239,7 @@ maybe_log_start_error(Reason, D) ->
                         cause => Reason}).
 
 handle_socket_error(closed, _State, D) ->
-    {stop, normal, D};
+    listener_socket_closed(D);
 %% {error, econnaborted} -> accept
 handle_socket_error(econnaborted, State, D) ->
     {next_state, State, D, {next_event, internal, accept}};
@@ -248,6 +251,10 @@ handle_socket_error(Reason, _State, D) when Reason =:= emfile; Reason =:= enfile
     enter_suspending(D, ?SYS_LIMIT_SUSPEND_MS);
 handle_socket_error(Reason, _State, D) ->
     {stop, Reason, D}.
+
+listener_socket_closed(#d{listener = Listener} = D) ->
+    Listener ! {listen_socket_closed, self()},
+    {stop, normal, D}.
 
 explain_posix(emfile) ->
     "EMFILE (Too many open files)";

--- a/src/esockd_socket_listener.erl
+++ b/src/esockd_socket_listener.erl
@@ -99,7 +99,6 @@ init({Proto, ListenOn, Opts}) ->
     TcpOpts = merge_defaults(proplists:get_value(tcp_options, Opts, [])),
     case listen(ListenOn, TcpOpts) of
         {ok, LSock, SockParams} ->
-            _MRef = socket:monitor(LSock),
             case esockd_socket:sockname(LSock) of
                 {ok, {LAddr, LPort}} ->
                     {ok, #state{listener_ref = ListenerRef, lsock = LSock,
@@ -203,9 +202,8 @@ handle_cast(Msg, State) ->
     error_logger:error_msg("[~s] Unexpected cast: ~p", [?MODULE, Msg]),
     {noreply, State}.
 
-handle_info({'DOWN', _MRef, socket, LSock, Info}, #state{lsock = LSock} = State) ->
-    error_logger:error_msg("[~s] Socket ~p closed: ~p", [?MODULE, LSock, Info]),
-    {stop, Info, State};
+handle_info({listen_socket_closed, _Acceptor}, State) ->
+    {stop, listen_socket_closed, State};
 handle_info(Info, State) ->
     error_logger:error_msg("[~s] Unexpected info: ~p", [?MODULE, Info]),
     {noreply, State}.

--- a/test/esockd_SUITE.erl
+++ b/test/esockd_SUITE.erl
@@ -106,6 +106,54 @@ t_open_tcpsocket(_) ->
              _Child}} =
         esockd:open_tcpsocket(echo, {"0.0.0.0", 6000}, [{tcp_options, [inet6]}]).
 
+t_tcpsocket_listener_recovers_from_closed_lsock(_) ->
+    LPort = 6002,
+    Name = ?FUNCTION_NAME,
+    {ok, LSup} = esockd:open_tcpsocket(
+        Name,
+        LPort,
+        [{acceptors, 4}, {connection_mfargs, echo_server}]
+    ),
+    {esockd_socket_listener, Listener} = esockd_listener_sup:listener(LSup),
+    LSock = esockd_socket_listener:get_lsock(Listener),
+    ConnSup = esockd_listener_sup:connection_sup(LSup),
+    AcceptorSup = esockd_listener_sup:acceptor_sup(LSup),
+    Acceptors = get_acceptors(LSup),
+    %% Estabilish a connection:
+    {ok, Sock1} = gen_tcp:connect("localhost", LPort, [binary, {active, false}]),
+    ok = gen_tcp:send(Sock1, <<"before restart">>),
+    {ok, <<"before restart">>} = gen_tcp:recv(Sock1, 0, 1000),
+    %% Force-close listening socket:
+    ListenerMRef = monitor(process, Listener),
+    ok = socket:close(LSock),
+    receive
+        {'DOWN', ListenerMRef, process, Listener, listen_socket_closed} ->
+            ok
+    after
+        1000 ->
+            ct:fail(listener_still_alive)
+    end,
+    ok = timer:sleep(1000),
+    %% Connection supervisor is still the same:
+    ?assert(is_process_alive(ConnSup)),
+    %% Listener restarted:
+    ?assertMatch(
+        {esockd_socket_listener, L} when L =/= Listener,
+        esockd_listener_sup:listener(LSup)
+    ),
+    %% Acceptors were restarted:
+    ?assertNot(is_process_alive(AcceptorSup)),
+    ?assertNotEqual(AcceptorSup, esockd_listener_sup:acceptor_sup(LSup)),
+    ?assertEqual(length(Acceptors), length(get_acceptors(LSup))),
+    %% Pre-existing connection is intact:
+    ok = gen_tcp:send(Sock1, <<"after restart">>),
+    {ok, <<"after restart">>} = gen_tcp:recv(Sock1, 0, 1000),
+    {ok, Sock2} = gen_tcp:connect("localhost", LPort, [binary, {active, false}]),
+
+    gen_tcp:close(Sock2),
+    gen_tcp:close(Sock1),
+    esockd:close(Name, LPort).
+
 t_open_udp(_) ->
     {ok, _} = esockd:open_udp(echo, 5678,
                               [{connection_mfargs, {udp_echo_server, start_link}}]),

--- a/test/esockd_acceptor_fsm_SUITE.erl
+++ b/test/esockd_acceptor_fsm_SUITE.erl
@@ -66,6 +66,9 @@ end_per_group(_Group, _Config) ->
 init_per_testcase(_Case, Config) ->
     Counters = counters:new(?COUNTER_LAST, []),
     meck:new(esockd_server, [passthrough, no_history, no_sticky]),
+    Listener = self(),
+    meck:expect(esockd_server, get_listener_prop,
+                fun(_ListenerRef, listener) -> {?MODULE, Listener} end),
     meck:expect(esockd_server, inc_stats,
                 fun(_, Tag, Count) ->
                         Index =  counter_tag_to_index(Tag),
@@ -253,14 +256,21 @@ t_close_listener_socket_cause_acceptor_stop(Config) ->
             ?assertEqual(normal, Reason)
     after
         1000 ->
-            error(timeout)
+            error("Acceptor process did not terminate in time")
+    end,
+    receive
+        {listen_socket_closed, Acceptor} ->
+            ok
+    after
+        1000 ->
+            error("No listen socket closed notification")
     end,
     receive
         {tcp_closed, Sock1} ->
             ok
     after
         1000 ->
-            error(timeout)
+            error("Client socket still connected")
     end.
 
 assert_socket_connected(Sock) ->


### PR DESCRIPTION
## Summary

This PR changes `esockd_socket_listener` implementation: now there's no `socket:monitor/1` call.

This call forced use of _socket registry_ facility for the listen socket and ALL subsequently accepted sockets. When socket registry is disabled, this helps to avoid small extra memory cost per each `esockd_socket` connection.