### PR TITLE
feat(acceptor): count early-closed and forbidden sockets

### DIFF
--- a/include/esockd.hrl
+++ b/include/esockd.hrl
@@ -79,6 +79,11 @@
 -define(ARG_CLOSED_MAX_LIMIT, closed_max_limit).
 -define(ARG_CLOSED_OVERLOADED, closed_overloaded).
 -define(ARG_CLOSED_RATE_LIMITED, closed_rate_limited).
+%% The socket failed before the connection process was started,
+%% most likely because the peer closed or reset it.
+-define(ARG_CLOSED_EARLY, closed_early).
+%% The peer address is denied by the access rules.
+-define(ARG_CLOSED_FORBIDDEN, closed_forbidden).
 -define(ARG_CLOSED_OTHER_REASONS, closed_other_reasons).
 
 -define(ACCEPT_RESULT_GROUPS,
@@ -88,6 +93,8 @@
             ?ARG_CLOSED_MAX_LIMIT,
             ?ARG_CLOSED_OVERLOADED,
             ?ARG_CLOSED_RATE_LIMITED,
+            ?ARG_CLOSED_EARLY,
+            ?ARG_CLOSED_FORBIDDEN,
             ?ARG_CLOSED_OTHER_REASONS
         ]).
 

--- a/src/esockd_acceptor_fsm.erl
+++ b/src/esockd_acceptor_fsm.erl
@@ -123,6 +123,9 @@ handle_event(info, Message, State = {accepting, Ref, InState}, D) ->
     case async_accept_result(Message, Ref, D) of
         {ok, Sock} ->
             handle_accepted(Sock, InState, D);
+        {error, closed} ->
+            %% The listen socket is closed, no client socket to count.
+            listener_socket_closed(D);
         {error, Reason} ->
             inc_stats(D, Reason),
             handle_socket_error(Reason, InState, D);
@@ -238,8 +241,6 @@ maybe_log_start_error(Reason, D) ->
                         listener => format_sockname(D),
                         cause => Reason}).
 
-handle_socket_error(closed, _State, D) ->
-    listener_socket_closed(D);
 %% {error, econnaborted} -> accept
 handle_socket_error(econnaborted, State, D) ->
     {next_state, State, D, {next_event, internal, accept}};
@@ -285,6 +286,12 @@ counter(enfile) -> ?ARG_CLOSED_SYS_LIMIT;
 counter(?ERROR_MAXLIMIT) -> ?ARG_CLOSED_MAX_LIMIT;
 counter(overloaded) -> ?ARG_CLOSED_OVERLOADED;
 counter(rate_limited) -> ?ARG_CLOSED_RATE_LIMITED;
+counter(econnaborted) -> ?ARG_CLOSED_EARLY;
+counter(econnreset) -> ?ARG_CLOSED_EARLY;
+counter(enotconn) -> ?ARG_CLOSED_EARLY;
+counter(einval) -> ?ARG_CLOSED_EARLY;
+counter(closed) -> ?ARG_CLOSED_EARLY;
+counter(forbidden) -> ?ARG_CLOSED_FORBIDDEN;
 counter(_) -> ?ARG_CLOSED_OTHER_REASONS.
 
 start_connection(ConnSup, Transport, Sock, UpgradeFuns) when is_pid(ConnSup) ->

--- a/src/esockd_server.erl
+++ b/src/esockd_server.erl
@@ -90,8 +90,10 @@ inc_stats({Protocol, ListenOn}, Metric, Num) when is_integer(Num) ->
 dec_stats({Protocol, ListenOn}, Metric, Num) when is_integer(Num) ->
     update_counter({{Protocol, ListenOn}, Metric}, -Num).
 
+%% NOTE: The default row keeps the caller from crashing when the metric
+%% was not initialized, e.g. a listener started before the metric was added.
 update_counter(Key, Num) ->
-    ets:update_counter(?STATS_TAB, Key, {2, Num}).
+    ets:update_counter(?STATS_TAB, Key, {2, Num}, {Key, 0}).
 
 -spec(del_stats({atom(), esockd:listen_on()}) -> ok).
 del_stats({Protocol, ListenOn}) ->

--- a/test/esockd_SUITE.erl
+++ b/test/esockd_SUITE.erl
@@ -877,6 +877,69 @@ t_tune_fun_ok(_) ->
     ?assertEqual(1, proplists:get_value(accepted, Cnts)),
     ok = esockd:close(Name, LPort).
 
+%% A socket denied by the access rules is counted as `closed_forbidden'.
+t_closed_forbidden(_) ->
+    LPort = 7006,
+    Name = ?FUNCTION_NAME,
+    {ok, _LSup} = esockd:open(Name, LPort,
+                              [{access_rules, [{deny, "127.0.0.1/32"}]},
+                               {connection_mfargs, echo_server}]),
+    try
+        {ok, Socket} = gen_tcp:connect("127.0.0.1", LPort, [{active, true}]),
+        receive
+            {tcp_closed, Socket} -> ok
+        after 1000 ->
+            ct:fail(close_timeout)
+        end,
+        Cnts = esockd_server:get_stats({Name, LPort}),
+        ?assertEqual(0, proplists:get_value(accepted, Cnts)),
+        ?assertEqual(1, proplists:get_value(closed_forbidden, Cnts)),
+        ?assertEqual(0, proplists:get_value(closed_other_reasons, Cnts))
+    after
+        ok = esockd:close(Name, LPort)
+    end.
+
+%% A socket reset by the peer before the connection process is started
+%% is counted as `closed_early'.
+t_closed_early(_) ->
+    LPort = 7007,
+    Name = ?FUNCTION_NAME,
+    TuneFun = {?MODULE, sock_tune_fun_wait, [self()]},
+    {ok, _LSup} = esockd:open(Name, LPort,
+                              [{tune_fun, TuneFun},
+                               {connection_mfargs, echo_server}]),
+    try
+        {ok, Socket} = gen_tcp:connect("127.0.0.1", LPort, [{active, false}]),
+        %% The acceptor holds the accepted socket in tune_fun.
+        Acceptor = receive {tune_fun_wait, Pid} -> Pid
+                   after 1000 -> ct:fail(tune_fun_timeout)
+                   end,
+        %% Reset the connection from the client side.
+        ok = inet:setopts(Socket, [{linger, {true, 0}}]),
+        ok = gen_tcp:close(Socket),
+        Acceptor ! tune_fun_continue,
+        ok = wait_for_stats({Name, LPort}, closed_early, 1, 1000),
+        Cnts = esockd_server:get_stats({Name, LPort}),
+        ?assertEqual(0, proplists:get_value(accepted, Cnts)),
+        ?assertEqual(0, proplists:get_value(closed_other_reasons, Cnts))
+    after
+        ok = esockd:close(Name, LPort)
+    end.
+
+wait_for_stats(ListenerRef, Metric, Expected, Timeout) when Timeout > 0 ->
+    case proplists:get_value(Metric, esockd_server:get_stats(ListenerRef)) of
+        Expected ->
+            ok;
+        _ ->
+            timer:sleep(10),
+            wait_for_stats(ListenerRef, Metric, Expected, Timeout - 10)
+    end;
+wait_for_stats(ListenerRef, Metric, Expected, _Timeout) ->
+    ct:fail(#{cause => stats_timeout,
+              metric => Metric,
+              expected => Expected,
+              stats => esockd_server:get_stats(ListenerRef)}).
+
 
 t_listener_handle_port_exit_tcp(Config) ->
     do_listener_handle_port_exit(Config, false).
@@ -952,6 +1015,10 @@ do_listener_handle_port_exit(Config, IsTls) ->
 %% helper
 sock_tune_fun(Ret) ->
     Ret.
+
+sock_tune_fun_wait(TestPid) ->
+    TestPid ! {tune_fun_wait, self()},
+    receive tune_fun_continue -> ok end.
 
 -spec get_acceptors(supervisor:supervisor()) -> [Acceptor::pid()].
 get_acceptors(LSup) ->

--- a/test/esockd_acceptor_fsm_SUITE.erl
+++ b/test/esockd_acceptor_fsm_SUITE.erl
@@ -30,6 +30,8 @@
 -define(COUNTER_SYS_LIMIT, 4).
 -define(COUNTER_MAX_LIMIT, 5).
 -define(COUNTER_OTHER_REASONS, 6).
+-define(COUNTER_EARLY, 7).
+-define(COUNTER_FORBIDDEN, 8).
 -define(COUNTER_LAST, 10).
 
 counter_tag_to_index(accepted) -> ?COUNTER_ACCEPTED;
@@ -37,6 +39,8 @@ counter_tag_to_index(closed_sys_limit) -> ?COUNTER_SYS_LIMIT;
 counter_tag_to_index(closed_max_limit) -> ?COUNTER_MAX_LIMIT;
 counter_tag_to_index(closed_overloaded) -> ?COUNTER_OVERLOADED;
 counter_tag_to_index(closed_rate_limited) -> ?COUNTER_RATE_LIMITED;
+counter_tag_to_index(closed_early) -> ?COUNTER_EARLY;
+counter_tag_to_index(closed_forbidden) -> ?COUNTER_FORBIDDEN;
 counter_tag_to_index(closed_other_reasons) -> ?COUNTER_OTHER_REASONS.
 
 all() -> 
@@ -194,7 +198,54 @@ t_einval(Config) ->
     Server = start(Port, no_rate_limit(), Opts, Config),
     {ok, Sock1} = connect(Port),
     try
+        ok = wait_for_counter(Config, ?COUNTER_EARLY, 1, 2000),
+        ?assertEqual(0, get_counter(Config, ?COUNTER_OTHER_REASONS)),
+        disconnect(Sock1)
+    after
+        stop(Server)
+    end.
+
+%% Failed to tune the socket opts for a reason that is not a socket error
+t_tune_fun_other_error(Config) ->
+    Port = ?PORT,
+    Opts = #{tune_fun => {fun(_, _) -> {error, unknown} end, []}},
+    Server = start(Port, no_rate_limit(), Opts, Config),
+    {ok, Sock1} = connect(Port),
+    try
         ok = wait_for_counter(Config, ?COUNTER_OTHER_REASONS, 1, 2000),
+        ?assertEqual(0, get_counter(Config, ?COUNTER_EARLY)),
+        disconnect(Sock1)
+    after
+        stop(Server)
+    end.
+
+%% The socket is closed before the connection process is started
+t_closed_early(Config) ->
+    lists:foreach(
+      fun(Reason) ->
+              Port = ?PORT,
+              Opts = #{start_connection_result => {error, Reason}},
+              Server = start(Port, no_rate_limit(), Opts, Config),
+              {ok, Sock1} = connect(Port),
+              try
+                  ok = wait_for_counter(Config, ?COUNTER_EARLY, 1, 2000),
+                  ?assertEqual(0, get_counter(Config, ?COUNTER_OTHER_REASONS)),
+                  disconnect(Sock1)
+              after
+                  stop(Server),
+                  reset_counter(Config, ?COUNTER_EARLY)
+              end
+      end, [econnreset, enotconn, einval, closed]).
+
+%% The peer address is denied by the access rules
+t_forbidden(Config) ->
+    Port = ?PORT,
+    Opts = #{start_connection_result => {error, forbidden}},
+    Server = start(Port, no_rate_limit(), Opts, Config),
+    {ok, Sock1} = connect(Port),
+    try
+        ok = wait_for_counter(Config, ?COUNTER_FORBIDDEN, 1, 2000),
+        ?assertEqual(0, get_counter(Config, ?COUNTER_OTHER_REASONS)),
         disconnect(Sock1)
     after
         stop(Server)
@@ -258,6 +309,9 @@ t_close_listener_socket_cause_acceptor_stop(Config) ->
         1000 ->
             error("Acceptor process did not terminate in time")
     end,
+    %% A closed listen socket is not a closed client socket.
+    ?assertEqual(0, get_counter(Config, ?COUNTER_EARLY)),
+    ?assertEqual(0, get_counter(Config, ?COUNTER_OTHER_REASONS)),
     receive
         {listen_socket_closed, Acceptor} ->
             ok
@@ -325,6 +379,12 @@ consume(_Token, #{name := no_rate_limit} = Limiter) ->
     {ok, Limiter}.
 
 now_ts() -> erlang:system_time(millisecond).
+
+get_counter(Config, Index) ->
+    counters:get(proplists:get_value(counters, Config), Index).
+
+reset_counter(Config, Index) ->
+    counters:put(proplists:get_value(counters, Config), Index, 0).
 
 wait_for_counter(Config, Index, Count, Timeout) ->
     Counters = proplists:get_value(counters, Config),

--- a/test/esockd_server_SUITE.erl
+++ b/test/esockd_server_SUITE.erl
@@ -36,6 +36,16 @@ t_inc_dec_stats(_) ->
     [] = esockd_server:get_stats(Name),
     ok = esockd_server:stop().
 
+%% Updating a metric that was not initialized creates it.
+t_inc_uninitialized_stats(_) ->
+    {ok, _} = esockd_server:start_link(),
+    Name = {echo, 3000},
+    esockd_server:init_stats(Name, [accepting]),
+    esockd_server:inc_stats(Name, closed_early, 1),
+    ?assertEqual([{accepting, 0}, {closed_early, 1}],
+                 lists:sort(esockd_server:get_stats(Name))),
+    ok = esockd_server:stop().
+
 t_stats_fun(_) ->
     {ok, _} = esockd_server:start_link(),
     StatsFun = esockd_server:stats_fun({echo, 3000}, accepting),


### PR DESCRIPTION
The acceptor closes some sockets before a connection process starts. It counted most of them as `closed_other_reasons`. This PR splits out two new accept-result counters, which `esockd:get_stats/1` returns:

- `closed_early`: the socket failed with `econnaborted`, `econnreset`, `enotconn`, `einval` or `closed` before the connection process was started. This most likely means the peer closed or reset it. Scanners, health checks and load balancers usually cause these.
- `closed_forbidden`: the access rules denied the peer address.

`closed_other_reasons` now only counts `ignore`, connection start errors and crashes. A rise in this counter now points at a real problem.

## Related fixes

- `esockd_server:inc_stats/3` and `dec_stats/3` no longer crash the caller when the metric row is missing. They pass a default row to `ets:update_counter/4`. Without this, an acceptor on a listener started before the new counters existed would crash with `badarg` on its first early close.
- The acceptor no longer counts `{error, closed}` from an async accept. That error means the listen socket is closed, not a client socket. The sync accept path already skipped the count.

## Tests

- `esockd_acceptor_fsm_SUITE`: `t_closed_early`, `t_forbidden` and `t_tune_fun_other_error`. `t_einval` now expects `closed_early`. The listen-socket-closed case asserts that no close counter moves.
- `esockd_SUITE`: `t_closed_forbidden` uses a real deny rule. `t_closed_early` resets the client connection while the acceptor waits in `tune_fun`.
- `esockd_server_SUITE`: `t_inc_uninitialized_stats`.

Follow-up: EMQX only reads `esockd:get_shutdown_count/1` today. A separate EMQX PR will expose the accept-result counters in the CLI and in Prometheus.
