### PR TITLE
fix(pp): harden PPv2 parsing around zero-length proxy info

### DIFF
--- a/src/esockd_proxy_protocol.erl
+++ b/src/esockd_proxy_protocol.erl
@@ -201,8 +201,10 @@ recv_v2(Transport, Sock, Deadline) ->
         end
     end).
 
-%% A zero-length socket receive consumes application data rather than no bytes.
-recv_v2_body(_Transport, _Sock, 0, _Timeout) ->
+recv_v2_body(_Transport, _Sock, _Len = 0, _Timeout) ->
+    %% No extra proxy information, return empty binary.
+    %% Otherwise, a zero-length socket receive consumes application data available
+    %% in the socket buffers.
     {ok, <<>>};
 recv_v2_body(Transport, Sock, Len, Timeout) ->
     Transport:recv(Sock, Len, Timeout).

--- a/src/esockd_proxy_protocol.erl
+++ b/src/esockd_proxy_protocol.erl
@@ -137,6 +137,8 @@ recv_v1_esockd_socket(Sock, Deadline) ->
 
 recv_v2_esockd_socket(Sock, Deadline) ->
     case recv_v2(socket, Sock, Deadline) of
+        {ok, Sock} ->
+            {ok, Sock};
         {ok, ProxySock} ->
             ok = set_socket_meta(ProxySock),
             {ok, Sock};
@@ -181,7 +183,7 @@ recv_v2(Transport, Sock, Deadline) ->
         case Transport:recv(Sock, 14, HeaderTimeout) of
             {ok, <<?SIG, 2:4, Cmd:4, AF:4, Trans:4, Len:16>>} ->
                 with_remaining_timeout(Deadline, fun(ProxyInfoTimeout) ->
-                    case Transport:recv(Sock, Len, ProxyInfoTimeout) of
+                    case recv_v2_body(Transport, Sock, Len, ProxyInfoTimeout) of
                         {ok, ProxyInfo} ->
                             parse_v2(Cmd, Trans, ProxyInfo, #proxy_socket{inet = inet_family(AF), socket = Sock});
                         {error, closed} ->
@@ -198,6 +200,12 @@ recv_v2(Transport, Sock, Deadline) ->
                 {error, {recv_proxy_info_error, Reason}}
         end
     end).
+
+%% A zero-length socket receive consumes application data rather than no bytes.
+recv_v2_body(_Transport, _Sock, 0, _Timeout) ->
+    {ok, <<>>};
+recv_v2_body(Transport, Sock, Len, Timeout) ->
+    Transport:recv(Sock, Len, Timeout).
 
 mk_proxy_attrs(#proxy_socket{inet = Protocol,
                            src_addr = SrcAddr, dst_addr = DstAddr,
@@ -238,20 +246,26 @@ parse_v1(ProxyInfo, ProxySock) ->
 parse_v2(?LOCAL, _Trans, _ProxyInfo, #proxy_socket{socket = Sock}) ->
     {ok, Sock};
 
-parse_v2(?PROXY, ?STREAM, ProxyInfo, ProxySock = #proxy_socket{inet = inet4}) ->
+parse_v2(?PROXY, ?STREAM, ProxyInfo, ProxySock = #proxy_socket{inet = inet4})
+    when byte_size(ProxyInfo) >= 12 ->
     <<A:8, B:8, C:8, D:8, W:8, X:8, Y:8, Z:8,
       SrcPort:16, DstPort:16, AdditionalBytes/binary>> = ProxyInfo,
     parse_pp2_additional(AdditionalBytes, ProxySock#proxy_socket{
         src_addr = {A, B, C, D}, src_port = SrcPort,
         dst_addr = {W, X, Y, Z}, dst_port = DstPort});
 
-parse_v2(?PROXY, ?STREAM, ProxyInfo, ProxySock = #proxy_socket{inet = inet6}) ->
+parse_v2(?PROXY, ?STREAM, ProxyInfo, ProxySock = #proxy_socket{inet = inet6})
+    when byte_size(ProxyInfo) >= 36 ->
     <<A:16, B:16, C:16, D:16, E:16, F:16, G:16, H:16,
       R:16, S:16, T:16, U:16, V:16, W:16, X:16, Y:16,
       SrcPort:16, DstPort:16, AdditionalBytes/binary>> = ProxyInfo,
     parse_pp2_additional(AdditionalBytes, ProxySock#proxy_socket{
         src_addr = {A, B, C, D, E, F, G, H}, src_port = SrcPort,
         dst_addr = {R, S, T, U, V, W, X, Y}, dst_port = DstPort});
+
+parse_v2(?PROXY, ?STREAM, ProxyInfo, #proxy_socket{inet = Family})
+    when Family =:= inet4; Family =:= inet6 ->
+    {error, {invalid_proxy_info, ProxyInfo}};
 
 parse_v2(_, _, _, #proxy_socket{socket = _Sock}) ->
     {error, unsupported_proto_v2}.

--- a/src/esockd_transport.erl
+++ b/src/esockd_transport.erl
@@ -111,14 +111,22 @@ close(#proxy_socket{socket = Sock}) ->
 
 -spec(fast_close(socket()) -> ok).
 fast_close(Sock) when is_port(Sock) ->
-    catch port_close(Sock), ok;
+    fast_close_port(Sock);
 fast_close(#ssl_socket{tcp = Sock, ssl = SslSock}) ->
     _ = fast_close_sslsock(SslSock),
-    catch port_close(Sock), ok;
+    fast_close_port(Sock);
 fast_close(SslSock = #sslsocket{}) ->
     fast_close_sslsock(SslSock);
 fast_close(#proxy_socket{socket = Sock}) ->
     fast_close(Sock).
+
+%% @private
+fast_close_port(Sock) ->
+    try port_close(Sock) of
+        _ -> ok
+    catch
+        _:_ -> ok
+    end.
 
 %% @private
 fast_close_sslsock(SslSock) ->

--- a/src/esockd_udp.erl
+++ b/src/esockd_udp.erl
@@ -272,7 +272,8 @@ handle_info({udp, Sock, IP, Port, Request},
     {noreply, State};
 handle_info({udp, Sock, IP, InPortNo, Packet},
             State = #state{sock = Sock, peers = Peers, access_rules = Rules}) ->
-    case maps:find(Peer = {IP, InPortNo}, Peers) of
+    Peer = {IP, InPortNo},
+    case maps:find(Peer, Peers) of
         {ok, Pid} ->
             Pid ! {datagram, self(), Packet},
             {noreply, State};

--- a/test/esockd_proxy_protocol_SUITE.erl
+++ b/test/esockd_proxy_protocol_SUITE.erl
@@ -31,6 +31,14 @@ groups() ->
     SocketTCs = [t_recv_ppv1,
                  t_recv_ppv1_unknown,
                  t_recv_ppv2,
+                 t_recv_ppv2_local_empty,
+                 t_recv_ppv2_local_app_data,
+                 t_recv_ppv2_local_body,
+                 t_recv_ppv2_ipv4_empty_address,
+                 t_recv_ppv2_ipv4_short_address,
+                 t_recv_ppv2_ipv6_empty_address,
+                 t_recv_ppv2_ipv6_short_address,
+                 t_recv_ppv2_unspec,
                  t_recv_pp_invalid,
                  t_recv_pp_partial,
                  t_recv_socket_error],
@@ -129,6 +137,68 @@ t_recv_ppv2(Config) ->
         
         {ok, <<"Hello">>} = recv(Backend, ServerSide, 0)
     end).
+
+%% LOCAL must finish without waiting for application data.
+t_recv_ppv2_local_empty(Config) ->
+    check_ppv2_local(Config, <<>>, <<>>).
+
+%% A zero-length LOCAL body must leave coalesced application data untouched.
+t_recv_ppv2_local_app_data(Config) ->
+    check_ppv2_local(Config, <<>>, <<"Hello">>).
+
+%% LOCAL must skip exactly its declared body.
+t_recv_ppv2_local_body(Config) ->
+    check_ppv2_local(Config, <<"Ignored">>, <<"Hello">>).
+
+%% An empty IPv4 address block must be rejected without consuming application data.
+t_recv_ppv2_ipv4_empty_address(Config) ->
+    check_ppv2_short_address(Config, 16#11, 0, 12).
+
+%% An IPv4 address block one byte below the 12-byte minimum must be rejected.
+t_recv_ppv2_ipv4_short_address(Config) ->
+    check_ppv2_short_address(Config, 16#11, 11, 12).
+
+%% An empty IPv6 address block must be rejected without consuming application data.
+t_recv_ppv2_ipv6_empty_address(Config) ->
+    check_ppv2_short_address(Config, 16#21, 0, 36).
+
+%% An IPv6 address block one byte below the 36-byte minimum must be rejected.
+t_recv_ppv2_ipv6_short_address(Config) ->
+    check_ppv2_short_address(Config, 16#21, 35, 36).
+
+%% Unsupported zero-length frames must be rejected without waiting for a body.
+t_recv_ppv2_unspec(Config) ->
+    with_tcp_server(Config, fun(Backend, ServerSide, ClientSide) ->
+        ok = gen_tcp:send(ClientSide, ppv2_frame(1, 0, <<>>)),
+        ?assertEqual({error, unsupported_proto_v2},
+            esockd_proxy_protocol:recv(Backend, ServerSide, 1000))
+    end).
+
+check_ppv2_local(Config, Body, AppData) ->
+    with_tcp_server(Config, fun(Backend, ServerSide, ClientSide) ->
+        ok = gen_tcp:send(ClientSide, [ppv2_frame(0, 0, Body), AppData]),
+        ?assertEqual({ok, ServerSide},
+            esockd_proxy_protocol:recv(Backend, ServerSide, 1000)),
+        ?assertEqual(#{}, esockd_proxy_protocol:get_proxy_attrs(ServerSide)),
+        ok = gen_tcp:send(ClientSide, <<"Tail">>),
+        Expected = <<AppData/binary, "Tail">>,
+        ?assertEqual({ok, Expected}, recv(Backend, ServerSide, byte_size(Expected)))
+    end).
+
+%% Short address blocks must return an error without borrowing application bytes.
+check_ppv2_short_address(Config, Family, Length, MinLength) ->
+    with_tcp_server(Config, fun(Backend, ServerSide, ClientSide) ->
+        Body = binary:copy(<<0>>, Length),
+        AppData = binary:copy(<<0>>, MinLength),
+        ok = gen_tcp:send(ClientSide, [ppv2_frame(1, Family, Body), AppData]),
+        ?assertEqual({error, {invalid_proxy_info, Body}},
+            esockd_proxy_protocol:recv(Backend, ServerSide, 1000)),
+        ?assertEqual({ok, AppData}, recv(Backend, ServerSide, MinLength))
+    end).
+
+ppv2_frame(Cmd, Family, Body) ->
+    <<"\r\n\r\n", 0, "\r\nQUIT\n", 2:4, Cmd:4, Family:8,
+      (byte_size(Body)):16, Body/binary>>.
 
 t_recv_pp_invalid(Config) ->
     with_tcp_server(Config, fun(Backend, ServerSide, ClientSide) ->


### PR DESCRIPTION
## Summary

Before this PR, PPv2 header declaring zero-length "proxy information" data could accidentally consume application data.
